### PR TITLE
home.html: Django のキャッチフレーズを「締め切りに厳格な人たちのためのWebフレームワーク」に変更

### DIFF
--- a/djangoja_website/templates/home.html
+++ b/djangoja_website/templates/home.html
@@ -16,7 +16,7 @@
   <div class="span8">
     <div class="hero-unit">
       <h2>Django を体験しよう</h2>
-      <p>Django は、締め切りに追われる完璧主義者のためのWebフレームワークです。</p>
+      <p>Django は、締め切りに厳格な人たちのためのWebフレームワークです。</p>
       <p><a href="https://www.djangoproject.com/download/" class="btn btn-primary btn-large">最新版: 1.4.1</a> <a href="/doc/" class="btn btn-large">ドキュメント</a></p>
       Djangoは<a href="https://github.com/django/django/blob/master/LICENSE">BSDライセンス</a>のOSSです。
     </div>


### PR DESCRIPTION
変更箇所の原文は “perfectionists with deadlines” です。完璧主義者と訳すと、ありとあらゆることを完璧にこなそうとする人たちのような印象を受けますので、with を「…について」と捉えて「締め切りに厳格な人たち」と訳すほうが自然なような気がします。
