### PR TITLE
Update links only supported versions

### DIFF
--- a/djangoproject.jp/about/index.html
+++ b/djangoproject.jp/about/index.html
@@ -217,8 +217,8 @@ About
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/community/index.html
+++ b/djangoproject.jp/community/index.html
@@ -227,8 +227,8 @@ Community
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li class="active"

--- a/djangoproject.jp/events/index.html
+++ b/djangoproject.jp/events/index.html
@@ -223,8 +223,8 @@ Events
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li class="active"

--- a/djangoproject.jp/howtojoin-transifex/index.html
+++ b/djangoproject.jp/howtojoin-transifex/index.html
@@ -243,8 +243,8 @@ Transifexへのユーザー登録とDjangoドキュメント翻訳プロジェ�
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li class="active"
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="active"
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/howtotranslate/index.html
+++ b/djangoproject.jp/howtotranslate/index.html
@@ -246,8 +246,8 @@ TransifexでのDjangoドキュメント翻訳の進め方
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li class="active"
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="active"
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/index.html
+++ b/djangoproject.jp/index.html
@@ -271,8 +271,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/translate/index.html
+++ b/djangoproject.jp/translate/index.html
@@ -183,12 +183,12 @@
 <p>訳文の提出者が明らかなときは、断りのない限り、貢献者としてお名前やidを明記することがあります。</p>
 <h2>翻訳されたリソース一覧</h2>
 <ul>
+<li><a href="https://docs.djangoproject.com/ja/2.2/" target="_blank">2.2 ドキュメント</a></li>
 <li><a href="https://docs.djangoproject.com/ja/1.11/" target="_blank">1.11ドキュメント</a></li>
-<li><a href="https://docs.djangoproject.com/ja/1.9/" target="_blank">1.9ドキュメント</a></li>
 <li><a href="http://docs.djangoproject.jp/" target="_blank">1.4ドキュメント</a></li>
 <li><a href="/doc/ja/1.0/" target="_blank">1.0ドキュメント</a></li>
 </ul>
-<p>1.9ドキュメント以降は本家 djangoproject.com より配信されています。</p>
+<p>1.11ドキュメント以降は本家 djangoproject.com より配信されています。</p>
 <h2>旧ドキュメントの翻訳方法</h2>
 <ul>
 <li><a href="/translate_old/">1.4ドキュメントの翻訳方法</a></li>
@@ -229,8 +229,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li class="active"
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="active"
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/translate_old/index.html
+++ b/djangoproject.jp/translate_old/index.html
@@ -251,8 +251,8 @@ git diff 007bfddc1fc4977009e431cf9706408316b682af f95baa1d8a8a96f843745118c38b7d
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li class="active"
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="active"
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/16_rc_15_5_release/index.html
+++ b/djangoproject.jp/weblog/16_rc_15_5_release/index.html
@@ -653,8 +653,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/2012/07/26/django_pyramid_con_jp/index.html
+++ b/djangoproject.jp/weblog/2012/07/26/django_pyramid_con_jp/index.html
@@ -744,8 +744,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/2012/09/17/django-pyramid-con-jp-2012-finished/index.html
+++ b/djangoproject.jp/weblog/2012/09/17/django-pyramid-con-jp-2012-finished/index.html
@@ -677,8 +677,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/2013/01/05/django_1_5_rc_1/index.html
+++ b/djangoproject.jp/weblog/2013/01/05/django_1_5_rc_1/index.html
@@ -641,8 +641,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/2013/02/14/djangosprint_13_2/index.html
+++ b/djangoproject.jp/weblog/2013/02/14/djangosprint_13_2/index.html
@@ -660,8 +660,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/2013/09/23/django_1_5_4/index.html
+++ b/djangoproject.jp/weblog/2013/09/23/django_1_5_4/index.html
@@ -674,8 +674,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2012/10/index.html
+++ b/djangoproject.jp/weblog/archive/2012/10/index.html
@@ -549,8 +549,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2012/12/index.html
+++ b/djangoproject.jp/weblog/archive/2012/12/index.html
@@ -495,8 +495,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2012/7/index.html
+++ b/djangoproject.jp/weblog/archive/2012/7/index.html
@@ -495,8 +495,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2012/9/index.html
+++ b/djangoproject.jp/weblog/archive/2012/9/index.html
@@ -603,8 +603,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/1/index.html
+++ b/djangoproject.jp/weblog/archive/2013/1/index.html
@@ -549,8 +549,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/11/index.html
+++ b/djangoproject.jp/weblog/archive/2013/11/index.html
@@ -549,8 +549,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/12/index.html
+++ b/djangoproject.jp/weblog/archive/2013/12/index.html
@@ -495,8 +495,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/2/index.html
+++ b/djangoproject.jp/weblog/archive/2013/2/index.html
@@ -603,8 +603,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/3/index.html
+++ b/djangoproject.jp/weblog/archive/2013/3/index.html
@@ -549,8 +549,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/4/index.html
+++ b/djangoproject.jp/weblog/archive/2013/4/index.html
@@ -495,8 +495,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/5/index.html
+++ b/djangoproject.jp/weblog/archive/2013/5/index.html
@@ -495,8 +495,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/7/index.html
+++ b/djangoproject.jp/weblog/archive/2013/7/index.html
@@ -495,8 +495,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/8/index.html
+++ b/djangoproject.jp/weblog/archive/2013/8/index.html
@@ -495,8 +495,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/9/index.html
+++ b/djangoproject.jp/weblog/archive/2013/9/index.html
@@ -495,8 +495,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/1/index.html
+++ b/djangoproject.jp/weblog/archive/2014/1/index.html
@@ -495,8 +495,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/10/index.html
+++ b/djangoproject.jp/weblog/archive/2014/10/index.html
@@ -495,8 +495,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/2/index.html
+++ b/djangoproject.jp/weblog/archive/2014/2/index.html
@@ -495,8 +495,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/3/index.html
+++ b/djangoproject.jp/weblog/archive/2014/3/index.html
@@ -495,8 +495,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/4/index.html
+++ b/djangoproject.jp/weblog/archive/2014/4/index.html
@@ -493,8 +493,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/5/index.html
+++ b/djangoproject.jp/weblog/archive/2014/5/index.html
@@ -493,8 +493,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/6/index.html
+++ b/djangoproject.jp/weblog/archive/2014/6/index.html
@@ -547,8 +547,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/7/index.html
+++ b/djangoproject.jp/weblog/archive/2014/7/index.html
@@ -495,8 +495,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/8/index.html
+++ b/djangoproject.jp/weblog/archive/2014/8/index.html
@@ -495,8 +495,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/9/index.html
+++ b/djangoproject.jp/weblog/archive/2014/9/index.html
@@ -495,8 +495,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2015/4/index.html
+++ b/djangoproject.jp/weblog/archive/2015/4/index.html
@@ -537,8 +537,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2015/5/index.html
+++ b/djangoproject.jp/weblog/archive/2015/5/index.html
@@ -545,8 +545,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2015/6/index.html
+++ b/djangoproject.jp/weblog/archive/2015/6/index.html
@@ -485,8 +485,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2016/12/index.html
+++ b/djangoproject.jp/weblog/archive/2016/12/index.html
@@ -493,8 +493,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html
@@ -732,8 +732,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=1
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=1
@@ -95,9 +95,9 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
         id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
                "
@@ -738,8 +738,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=2
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=2
@@ -95,9 +95,9 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
         id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
                "
@@ -762,8 +762,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=3
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=3
@@ -95,9 +95,9 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
         id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
                "
@@ -758,8 +758,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=4
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=4
@@ -95,9 +95,9 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
         id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
                "
@@ -764,8 +764,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=5
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=5
@@ -95,9 +95,9 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
         id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
                "
@@ -764,8 +764,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=6
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=6
@@ -95,9 +95,9 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
         id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
                "
@@ -764,8 +764,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=7
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=7
@@ -95,9 +95,9 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
         id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
                "
@@ -764,8 +764,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=8
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=8
@@ -95,9 +95,9 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
         id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
                "
@@ -710,8 +710,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/dajngo-1-8/index.html
+++ b/djangoproject.jp/weblog/dajngo-1-8/index.html
@@ -642,8 +642,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/delays_in_the_final_release_of_django_1_5/index.html
+++ b/djangoproject.jp/weblog/delays_in_the_final_release_of_django_1_5/index.html
@@ -643,8 +643,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-1-6-alpha-1/index.html
+++ b/djangoproject.jp/weblog/django-1-6-alpha-1/index.html
@@ -640,8 +640,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-1-6-beta-1/index.html
+++ b/djangoproject.jp/weblog/django-1-6-beta-1/index.html
@@ -639,8 +639,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-16/index.html
+++ b/djangoproject.jp/weblog/django-16/index.html
@@ -654,8 +654,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-17-alpha-1/index.html
+++ b/djangoproject.jp/weblog/django-17-alpha-1/index.html
@@ -652,8 +652,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-17-beta-1/index.html
+++ b/djangoproject.jp/weblog/django-17-beta-1/index.html
@@ -640,8 +640,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-1_6_5/index.html
+++ b/djangoproject.jp/weblog/django-1_6_5/index.html
@@ -646,8 +646,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-1_7_rc_1/index.html
+++ b/djangoproject.jp/weblog/django-1_7_rc_1/index.html
@@ -637,8 +637,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-1_7_rc_2/index.html
+++ b/djangoproject.jp/weblog/django-1_7_rc_2/index.html
@@ -637,8 +637,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-girls-tokyo-announcement/index.html
+++ b/djangoproject.jp/weblog/django-girls-tokyo-announcement/index.html
@@ -565,8 +565,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-pyramid-con-jp-2012-finished/index.html
+++ b/djangoproject.jp/weblog/django-pyramid-con-jp-2012-finished/index.html
@@ -677,8 +677,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django161/index.html
+++ b/djangoproject.jp/weblog/django161/index.html
@@ -641,8 +641,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django162-17a2/index.html
+++ b/djangoproject.jp/weblog/django162-17a2/index.html
@@ -648,8 +648,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django1_6_4/index.html
+++ b/djangoproject.jp/weblog/django1_6_4/index.html
@@ -632,8 +632,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_1_5/index.html
+++ b/djangoproject.jp/weblog/django_1_5/index.html
@@ -680,8 +680,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_1_5_1/index.html
+++ b/djangoproject.jp/weblog/django_1_5_1/index.html
@@ -653,8 +653,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_1_5_4/index.html
+++ b/djangoproject.jp/weblog/django_1_5_4/index.html
@@ -674,8 +674,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_1_5_rc_1/index.html
+++ b/djangoproject.jp/weblog/django_1_5_rc_1/index.html
@@ -641,8 +641,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_1_5_rc_2/index.html
+++ b/djangoproject.jp/weblog/django_1_5_rc_2/index.html
@@ -676,8 +676,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_1_7/index.html
+++ b/djangoproject.jp/weblog/django_1_7/index.html
@@ -650,8 +650,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_1_7_1/index.html
+++ b/djangoproject.jp/weblog/django_1_7_1/index.html
@@ -644,8 +644,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_pyramid_con_jp/index.html
+++ b/djangoproject.jp/weblog/django_pyramid_con_jp/index.html
@@ -744,8 +744,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_pyramid_con_jp_afterreport/index.html
+++ b/djangoproject.jp/weblog/django_pyramid_con_jp_afterreport/index.html
@@ -641,8 +641,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/djangosprint_13_2/index.html
+++ b/djangoproject.jp/weblog/djangosprint_13_2/index.html
@@ -660,8 +660,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/djangosprint_13_2_report/index.html
+++ b/djangoproject.jp/weblog/djangosprint_13_2_report/index.html
@@ -701,8 +701,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/improved-trans-page/index.html
+++ b/djangoproject.jp/weblog/improved-trans-page/index.html
@@ -640,8 +640,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/index.html
+++ b/djangoproject.jp/weblog/index.html
@@ -724,8 +724,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/index.html?page=1
+++ b/djangoproject.jp/weblog/index.html?page=1
@@ -95,9 +95,9 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
         id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
                "
@@ -730,8 +730,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/index.html?page=2
+++ b/djangoproject.jp/weblog/index.html?page=2
@@ -95,9 +95,9 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
         id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
                "
@@ -754,8 +754,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/index.html?page=3
+++ b/djangoproject.jp/weblog/index.html?page=3
@@ -95,9 +95,9 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
         id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
                "
@@ -750,8 +750,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/index.html?page=4
+++ b/djangoproject.jp/weblog/index.html?page=4
@@ -95,9 +95,9 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
         id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
                "
@@ -756,8 +756,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/index.html?page=5
+++ b/djangoproject.jp/weblog/index.html?page=5
@@ -95,9 +95,9 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
         id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
                "
@@ -756,8 +756,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/index.html?page=6
+++ b/djangoproject.jp/weblog/index.html?page=6
@@ -95,9 +95,9 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
         id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
                "
@@ -756,8 +756,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/index.html?page=7
+++ b/djangoproject.jp/weblog/index.html?page=7
@@ -95,9 +95,9 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
         id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
                "
@@ -756,8 +756,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/index.html?page=8
+++ b/djangoproject.jp/weblog/index.html?page=8
@@ -95,9 +95,9 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li class="
                "
-        id="https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li class="
+        id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
         id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
                "
@@ -702,8 +702,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/kickstarting_schema_migration_for_django/index.html
+++ b/djangoproject.jp/weblog/kickstarting_schema_migration_for_django/index.html
@@ -644,8 +644,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/new_djangoprojectjp/index.html
+++ b/djangoproject.jp/weblog/new_djangoprojectjp/index.html
@@ -640,8 +640,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/outlook-of-documents/index.html
+++ b/djangoproject.jp/weblog/outlook-of-documents/index.html
@@ -661,8 +661,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/released_django1_6_3/index.html
+++ b/djangoproject.jp/weblog/released_django1_6_3/index.html
@@ -671,8 +671,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/released_django1_6_6/index.html
+++ b/djangoproject.jp/weblog/released_django1_6_6/index.html
@@ -661,8 +661,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/security_release_1_4_2/index.html
+++ b/djangoproject.jp/weblog/security_release_1_4_2/index.html
@@ -646,8 +646,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/security_release_1_4_3/index.html
+++ b/djangoproject.jp/weblog/security_release_1_4_3/index.html
@@ -663,8 +663,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/security_release_1_5_2/index.html
+++ b/djangoproject.jp/weblog/security_release_1_5_2/index.html
@@ -707,8 +707,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/survey-for-18-translation-result/index.html
+++ b/djangoproject.jp/weblog/survey-for-18-translation-result/index.html
@@ -643,8 +643,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/survey-for-18-translation/index.html
+++ b/djangoproject.jp/weblog/survey-for-18-translation/index.html
@@ -557,8 +557,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/tokyo-django-meetup-9/index.html
+++ b/djangoproject.jp/weblog/tokyo-django-meetup-9/index.html
@@ -644,8 +644,8 @@ $(function() {
             id="footer-menu-about"><a href="/about/">About</a></li><li 
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/whouses/index.html
+++ b/djangoproject.jp/whouses/index.html
@@ -229,8 +229,8 @@
             id="footer-menu-about"><a href="/about/">About</a></li><li class="active"
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.9-"><a href="https://docs.djangoproject.com/ja/1.9/">1.9ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
             id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 


### PR DESCRIPTION
Django 3.0リリースにより、Django 2.2がLTSに、Django 1.9がEOLになったので修正。

追加 https://docs.djangoproject.com/ja/2.2/
削除 https://docs.djangoproject.com/ja/1.9/

Django 2.1もあと20日くらいサポートされているが二度手間は避けたいので。。