### PR TITLE
Remove links to deprecated Django 1.4 docs

### DIFF
--- a/djangoproject.jp/about/index.html
+++ b/djangoproject.jp/about/index.html
@@ -219,7 +219,6 @@ About
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/community/index.html
+++ b/djangoproject.jp/community/index.html
@@ -229,7 +229,6 @@ Community
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li class="active"
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/events/index.html
+++ b/djangoproject.jp/events/index.html
@@ -225,7 +225,6 @@ Events
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li class="active"
             id="footer-menu-community"><a href="/community/">Community</a></li><li class="active"

--- a/djangoproject.jp/howtojoin-transifex/index.html
+++ b/djangoproject.jp/howtojoin-transifex/index.html
@@ -245,7 +245,6 @@ Transifexへのユーザー登録とDjangoドキュメント翻訳プロジェ�
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="active"
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/howtotranslate/index.html
+++ b/djangoproject.jp/howtotranslate/index.html
@@ -248,7 +248,6 @@ TransifexでのDjangoドキュメント翻訳の進め方
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="active"
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/index.html
+++ b/djangoproject.jp/index.html
@@ -273,7 +273,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/translate/index.html
+++ b/djangoproject.jp/translate/index.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="keywords" content="" />
-<meta name="description" content="最新ドキュメント翻訳現在ドキュメントを国際化するプロジェクトがDjango本体で進行しており､ 最新版(1.11)ドキュメントをTransifexで翻訳中です｡" />
+<meta name="description" content="最新ドキュメント翻訳現在ドキュメントを国際化するプロジェクトがDjango本体で進行しており､ 最新版(3.0)ドキュメントをTransifexで翻訳中です｡" />
 <title>documentation / 翻訳への参加方法 | djangoproject.jp</title>
 <link rel="shortcut icon" href="/static/img/favicon.ico">
 
@@ -171,7 +171,7 @@
 
 
 <h2>最新ドキュメント翻訳</h2>
-<p>現在ドキュメントを国際化するプロジェクトがDjango本体で進行しており､ 最新版(1.11)ドキュメントをTransifexで翻訳中です｡</p>
+<p>現在ドキュメントを国際化するプロジェクトがDjango本体で進行しており､ 最新版(3.0)ドキュメントをTransifexで翻訳中です｡</p>
 <p> </p>
 <ul>
 <li><a href="/howtojoin-transifex/">ユーザー登録と参加方法</a>を読んでユーザーを登録します。</li>
@@ -183,12 +183,12 @@
 <p>訳文の提出者が明らかなときは、断りのない限り、貢献者としてお名前やidを明記することがあります。</p>
 <h2>翻訳されたリソース一覧</h2>
 <ul>
-<li><a href="https://docs.djangoproject.com/ja/2.2/" target="_blank">2.2 ドキュメント</a></li>
-<li><a href="https://docs.djangoproject.com/ja/1.11/" target="_blank">1.11ドキュメント</a></li>
-<li><a href="http://docs.djangoproject.jp/" target="_blank">1.4ドキュメント</a></li>
-<li><a href="/doc/ja/1.0/" target="_blank">1.0ドキュメント</a></li>
+<li><a href="https://docs.djangoproject.com/ja/" target="_blank">Django最新版のドキュメント</a></li>
+<li><a href="https://docs.djangoproject.com/ja/3.0/" target="_blank">3.0</a>, <a href="https://docs.djangoproject.com/ja/2.2/" target="_blank">2.2</a>, <a href="https://docs.djangoproject.com/ja/2.1/" target="_blank">2.1</a>, <a href="https://docs.djangoproject.com/ja/3.0/" target="_blank">2.0</a>, <a href="https://docs.djangoproject.com/ja/1.11/" target="_blank">1.11</a>, <a href="https://docs.djangoproject.com/ja/1.10/" target="_blank">1.10</a>, <a href="https://docs.djangoproject.com/ja/1.9/" target="_blank">1.9</a></li>
+<li>1.4ドキュメント (公開終了)</li>
+<li><a href="/doc/ja/1.0/" target="_blank">1.0ドキュメント (Django本体のサポート終了)</a></li>
 </ul>
-<p>1.11ドキュメント以降は本家 djangoproject.com より配信されています。</p>
+<p>1.9ドキュメント以降は本家 djangoproject.com より配信されています。</p>
 <h2>旧ドキュメントの翻訳方法</h2>
 <ul>
 <li><a href="/translate_old/">1.4ドキュメントの翻訳方法</a></li>
@@ -231,7 +231,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="active"
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/translate_old/index.html
+++ b/djangoproject.jp/translate_old/index.html
@@ -253,7 +253,6 @@ git diff 007bfddc1fc4977009e431cf9706408316b682af f95baa1d8a8a96f843745118c38b7d
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="active"
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/16_rc_15_5_release/index.html
+++ b/djangoproject.jp/weblog/16_rc_15_5_release/index.html
@@ -655,7 +655,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/2012/07/26/django_pyramid_con_jp/index.html
+++ b/djangoproject.jp/weblog/2012/07/26/django_pyramid_con_jp/index.html
@@ -746,7 +746,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/2012/09/17/django-pyramid-con-jp-2012-finished/index.html
+++ b/djangoproject.jp/weblog/2012/09/17/django-pyramid-con-jp-2012-finished/index.html
@@ -679,7 +679,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/2013/01/05/django_1_5_rc_1/index.html
+++ b/djangoproject.jp/weblog/2013/01/05/django_1_5_rc_1/index.html
@@ -643,7 +643,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/2013/02/14/djangosprint_13_2/index.html
+++ b/djangoproject.jp/weblog/2013/02/14/djangosprint_13_2/index.html
@@ -662,7 +662,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/2013/09/23/django_1_5_4/index.html
+++ b/djangoproject.jp/weblog/2013/09/23/django_1_5_4/index.html
@@ -676,7 +676,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2012/10/index.html
+++ b/djangoproject.jp/weblog/archive/2012/10/index.html
@@ -551,7 +551,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2012/12/index.html
+++ b/djangoproject.jp/weblog/archive/2012/12/index.html
@@ -497,7 +497,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2012/7/index.html
+++ b/djangoproject.jp/weblog/archive/2012/7/index.html
@@ -497,7 +497,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2012/9/index.html
+++ b/djangoproject.jp/weblog/archive/2012/9/index.html
@@ -605,7 +605,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2013/1/index.html
+++ b/djangoproject.jp/weblog/archive/2013/1/index.html
@@ -551,7 +551,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2013/11/index.html
+++ b/djangoproject.jp/weblog/archive/2013/11/index.html
@@ -551,7 +551,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2013/12/index.html
+++ b/djangoproject.jp/weblog/archive/2013/12/index.html
@@ -497,7 +497,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2013/2/index.html
+++ b/djangoproject.jp/weblog/archive/2013/2/index.html
@@ -605,7 +605,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2013/3/index.html
+++ b/djangoproject.jp/weblog/archive/2013/3/index.html
@@ -551,7 +551,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2013/4/index.html
+++ b/djangoproject.jp/weblog/archive/2013/4/index.html
@@ -497,7 +497,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2013/5/index.html
+++ b/djangoproject.jp/weblog/archive/2013/5/index.html
@@ -497,7 +497,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2013/7/index.html
+++ b/djangoproject.jp/weblog/archive/2013/7/index.html
@@ -497,7 +497,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2013/8/index.html
+++ b/djangoproject.jp/weblog/archive/2013/8/index.html
@@ -497,7 +497,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2013/9/index.html
+++ b/djangoproject.jp/weblog/archive/2013/9/index.html
@@ -497,7 +497,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2014/1/index.html
+++ b/djangoproject.jp/weblog/archive/2014/1/index.html
@@ -497,7 +497,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2014/10/index.html
+++ b/djangoproject.jp/weblog/archive/2014/10/index.html
@@ -497,7 +497,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2014/2/index.html
+++ b/djangoproject.jp/weblog/archive/2014/2/index.html
@@ -497,7 +497,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2014/3/index.html
+++ b/djangoproject.jp/weblog/archive/2014/3/index.html
@@ -497,7 +497,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2014/4/index.html
+++ b/djangoproject.jp/weblog/archive/2014/4/index.html
@@ -495,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2014/5/index.html
+++ b/djangoproject.jp/weblog/archive/2014/5/index.html
@@ -495,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2014/6/index.html
+++ b/djangoproject.jp/weblog/archive/2014/6/index.html
@@ -549,7 +549,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2014/7/index.html
+++ b/djangoproject.jp/weblog/archive/2014/7/index.html
@@ -497,7 +497,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2014/8/index.html
+++ b/djangoproject.jp/weblog/archive/2014/8/index.html
@@ -497,7 +497,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2014/9/index.html
+++ b/djangoproject.jp/weblog/archive/2014/9/index.html
@@ -497,7 +497,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2015/4/index.html
+++ b/djangoproject.jp/weblog/archive/2015/4/index.html
@@ -539,7 +539,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2015/5/index.html
+++ b/djangoproject.jp/weblog/archive/2015/5/index.html
@@ -547,7 +547,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2015/6/index.html
+++ b/djangoproject.jp/weblog/archive/2015/6/index.html
@@ -487,7 +487,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/archive/2016/12/index.html
+++ b/djangoproject.jp/weblog/archive/2016/12/index.html
@@ -495,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html
@@ -734,7 +734,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=1
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=1
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
-               "
         id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
@@ -740,7 +738,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=2
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=2
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
-               "
         id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
@@ -764,7 +762,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=3
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=3
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
-               "
         id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
@@ -760,7 +758,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=4
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=4
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
-               "
         id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
@@ -766,7 +764,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=5
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=5
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
-               "
         id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
@@ -766,7 +764,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=6
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=6
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
-               "
         id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
@@ -766,7 +764,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=7
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=7
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
-               "
         id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
@@ -766,7 +764,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=8
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=8
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
-               "
         id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
@@ -712,7 +710,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/dajngo-1-8/index.html
+++ b/djangoproject.jp/weblog/dajngo-1-8/index.html
@@ -644,7 +644,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/delays_in_the_final_release_of_django_1_5/index.html
+++ b/djangoproject.jp/weblog/delays_in_the_final_release_of_django_1_5/index.html
@@ -645,7 +645,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django-1-6-alpha-1/index.html
+++ b/djangoproject.jp/weblog/django-1-6-alpha-1/index.html
@@ -642,7 +642,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django-1-6-beta-1/index.html
+++ b/djangoproject.jp/weblog/django-1-6-beta-1/index.html
@@ -641,7 +641,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django-16/index.html
+++ b/djangoproject.jp/weblog/django-16/index.html
@@ -656,7 +656,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django-17-alpha-1/index.html
+++ b/djangoproject.jp/weblog/django-17-alpha-1/index.html
@@ -654,7 +654,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django-17-beta-1/index.html
+++ b/djangoproject.jp/weblog/django-17-beta-1/index.html
@@ -642,7 +642,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django-1_6_5/index.html
+++ b/djangoproject.jp/weblog/django-1_6_5/index.html
@@ -648,7 +648,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django-1_7_rc_1/index.html
+++ b/djangoproject.jp/weblog/django-1_7_rc_1/index.html
@@ -639,7 +639,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django-1_7_rc_2/index.html
+++ b/djangoproject.jp/weblog/django-1_7_rc_2/index.html
@@ -639,7 +639,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django-girls-tokyo-announcement/index.html
+++ b/djangoproject.jp/weblog/django-girls-tokyo-announcement/index.html
@@ -567,7 +567,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django-pyramid-con-jp-2012-finished/index.html
+++ b/djangoproject.jp/weblog/django-pyramid-con-jp-2012-finished/index.html
@@ -679,7 +679,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django161/index.html
+++ b/djangoproject.jp/weblog/django161/index.html
@@ -643,7 +643,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django162-17a2/index.html
+++ b/djangoproject.jp/weblog/django162-17a2/index.html
@@ -650,7 +650,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django1_6_4/index.html
+++ b/djangoproject.jp/weblog/django1_6_4/index.html
@@ -634,7 +634,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django_1_5/index.html
+++ b/djangoproject.jp/weblog/django_1_5/index.html
@@ -682,7 +682,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django_1_5_1/index.html
+++ b/djangoproject.jp/weblog/django_1_5_1/index.html
@@ -655,7 +655,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django_1_5_4/index.html
+++ b/djangoproject.jp/weblog/django_1_5_4/index.html
@@ -676,7 +676,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django_1_5_rc_1/index.html
+++ b/djangoproject.jp/weblog/django_1_5_rc_1/index.html
@@ -643,7 +643,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django_1_5_rc_2/index.html
+++ b/djangoproject.jp/weblog/django_1_5_rc_2/index.html
@@ -678,7 +678,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django_1_7/index.html
+++ b/djangoproject.jp/weblog/django_1_7/index.html
@@ -652,7 +652,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django_1_7_1/index.html
+++ b/djangoproject.jp/weblog/django_1_7_1/index.html
@@ -646,7 +646,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django_pyramid_con_jp/index.html
+++ b/djangoproject.jp/weblog/django_pyramid_con_jp/index.html
@@ -746,7 +746,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/django_pyramid_con_jp_afterreport/index.html
+++ b/djangoproject.jp/weblog/django_pyramid_con_jp_afterreport/index.html
@@ -643,7 +643,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/djangosprint_13_2/index.html
+++ b/djangoproject.jp/weblog/djangosprint_13_2/index.html
@@ -662,7 +662,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/djangosprint_13_2_report/index.html
+++ b/djangoproject.jp/weblog/djangosprint_13_2_report/index.html
@@ -703,7 +703,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/improved-trans-page/index.html
+++ b/djangoproject.jp/weblog/improved-trans-page/index.html
@@ -642,7 +642,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/index.html
+++ b/djangoproject.jp/weblog/index.html
@@ -726,7 +726,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/index.html?page=1
+++ b/djangoproject.jp/weblog/index.html?page=1
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
-               "
         id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
@@ -732,7 +730,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/index.html?page=2
+++ b/djangoproject.jp/weblog/index.html?page=2
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
-               "
         id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
@@ -756,7 +754,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/index.html?page=3
+++ b/djangoproject.jp/weblog/index.html?page=3
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
-               "
         id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
@@ -752,7 +750,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/index.html?page=4
+++ b/djangoproject.jp/weblog/index.html?page=4
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
-               "
         id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
@@ -758,7 +756,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/index.html?page=5
+++ b/djangoproject.jp/weblog/index.html?page=5
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
-               "
         id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
@@ -758,7 +756,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/index.html?page=6
+++ b/djangoproject.jp/weblog/index.html?page=6
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
-               "
         id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
@@ -758,7 +756,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/index.html?page=7
+++ b/djangoproject.jp/weblog/index.html?page=7
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
-               "
         id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
@@ -758,7 +756,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/index.html?page=8
+++ b/djangoproject.jp/weblog/index.html?page=8
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li class="
-               "
         id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
@@ -704,7 +702,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/kickstarting_schema_migration_for_django/index.html
+++ b/djangoproject.jp/weblog/kickstarting_schema_migration_for_django/index.html
@@ -646,7 +646,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/new_djangoprojectjp/index.html
+++ b/djangoproject.jp/weblog/new_djangoprojectjp/index.html
@@ -642,7 +642,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/outlook-of-documents/index.html
+++ b/djangoproject.jp/weblog/outlook-of-documents/index.html
@@ -663,7 +663,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/released_django1_6_3/index.html
+++ b/djangoproject.jp/weblog/released_django1_6_3/index.html
@@ -673,7 +673,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/released_django1_6_6/index.html
+++ b/djangoproject.jp/weblog/released_django1_6_6/index.html
@@ -663,7 +663,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/security_release_1_4_2/index.html
+++ b/djangoproject.jp/weblog/security_release_1_4_2/index.html
@@ -648,7 +648,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/security_release_1_4_3/index.html
+++ b/djangoproject.jp/weblog/security_release_1_4_3/index.html
@@ -665,7 +665,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/security_release_1_5_2/index.html
+++ b/djangoproject.jp/weblog/security_release_1_5_2/index.html
@@ -709,7 +709,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/survey-for-18-translation-result/index.html
+++ b/djangoproject.jp/weblog/survey-for-18-translation-result/index.html
@@ -645,7 +645,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/survey-for-18-translation/index.html
+++ b/djangoproject.jp/weblog/survey-for-18-translation/index.html
@@ -559,7 +559,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/weblog/tokyo-django-meetup-9/index.html
+++ b/djangoproject.jp/weblog/tokyo-django-meetup-9/index.html
@@ -646,7 +646,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 

--- a/djangoproject.jp/whouses/index.html
+++ b/djangoproject.jp/whouses/index.html
@@ -231,7 +231,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu-http:--docs.djangoproject.jp-"><a href="http://docs.djangoproject.jp/">1.4ドキュメント</a></li><li 
             id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 


### PR DESCRIPTION
Django 1.4 docs (ja) へのリンク `http://docs.djangoproject.jp/` は Django 3.0 (2019-12現在) docs/ja へのリンクとなっている (cf. django-ja/docs.djangoproject.jp@325285ab7ba1933c1fec57db3215aace462e0143) ので、全ページから当該リンクを一括削除

Django 1.4 docsの歴史はこちらで一元管理する: https://djangoproject.jp/translate/