### PR TITLE
Add outdated warnings to Django docs 1.0

### DIFF
--- a/djangoproject.jp/doc/ja/1.0/_static/djangodocs.css
+++ b/djangoproject.jp/doc/ja/1.0/_static/djangodocs.css
@@ -30,7 +30,7 @@ div.nav { margin: 0; font-size: 11px; text-align: right; color: #487858;}
 #hd div.nav { margin-top: -27px; }
 #ft div.nav { margin-bottom: -18px; }
 #hd h1 a { color: white; }
-#global-nav { position:absolute; top:5px; margin-left: -5px; padding:7px 0; color:#263E2B; }
+#global-nav { padding:7px 0; color:#263E2B; }
 #global-nav a:link, #global-nav a:visited {color:#487858;}
 #global-nav a {padding:0 4px;}
 #global-nav a.about {padding-left:0;}
@@ -128,3 +128,6 @@ div#contents ul ul li { margin-top: 0.3em;}
 
 /*** IE hacks ***/
 * pre { width: 100%; }
+
+/*** Warning for outdated version ***/
+#outdated-warning { background-color: #FFBABA; color: #6A0E0E; position: absolute; top: 0; width: 100%; padding: 8px 20px 8px; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; background-image: -webkit-linear-gradient(-45deg, rgba(0,0,0,0.04) 25%, transparent 25%, transparent 50%, rgba(0,0,0,0.04) 50%, rgba(0,0,0,0.04) 75%, transparent 75%, transparent); background-image: -moz-linear-gradient(-45deg, rgba(0,0,0,0.04) 25%, transparent 25%, transparent 50%, rgba(0,0,0,0.04) 50%, rgba(0,0,0,0.04) 75%, transparent 75%, transparent); background-image: linear-gradient(135deg, rgba(0,0,0,0.04) 25%, transparent 25%, transparent 50%, rgba(0,0,0,0.04) 50%, rgba(0,0,0,0.04) 75%, transparent 75%, transparent); font-family: "Roboto", Corbel, Avenir, "Lucida Grande", "Lucida Sans", sans-serif; font-size: 14px; text-align: center; @media screen and (min-width: 768px) { position: fixed; min-width: 768px; } }

--- a/djangoproject.jp/doc/ja/1.0/contents.html
+++ b/djangoproject.jp/doc/ja/1.0/contents.html
@@ -22,6 +22,9 @@
     <link rel="next" title="さあ始めましょう" href="intro/index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/faq/admin.html
+++ b/djangoproject.jp/doc/ja/1.0/faq/admin.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="FAQ: データベースとモデル" href="models.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/faq/contributing.html
+++ b/djangoproject.jp/doc/ja/1.0/faq/contributing.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="FAQ: admin" href="admin.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/faq/general.html
+++ b/djangoproject.jp/doc/ja/1.0/faq/general.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django FAQ" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/faq/help.html
+++ b/djangoproject.jp/doc/ja/1.0/faq/help.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="FAQ: Django を使う" href="usage.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/faq/index.html
+++ b/djangoproject.jp/doc/ja/1.0/faq/index.html
@@ -23,6 +23,9 @@
     <link rel="prev" title="静的なファイルの提供方法" href="../howto/static-files.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/faq/install.html
+++ b/djangoproject.jp/doc/ja/1.0/faq/install.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="FAQ: 全般" href="general.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/faq/models.html
+++ b/djangoproject.jp/doc/ja/1.0/faq/models.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="FAQ: 助けを求める" href="help.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/faq/usage.html
+++ b/djangoproject.jp/doc/ja/1.0/faq/usage.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="FAQ: インストール" href="install.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/genindex.html
+++ b/djangoproject.jp/doc/ja/1.0/genindex.html
@@ -21,6 +21,9 @@
     <link rel="top" title="Django v1.0 documentation" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="">
     <div id="hd">
       <h1><a href="index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/glossary.html
+++ b/djangoproject.jp/doc/ja/1.0/glossary.html
@@ -23,6 +23,9 @@
     <link rel="prev" title="サードパーティによる Django ディストリビューション" href="misc/distributions.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/howto/apache-auth.html
+++ b/djangoproject.jp/doc/ja/1.0/howto/apache-auth.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="HOWTO ガイド" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/howto/custom-file-storage.html
+++ b/djangoproject.jp/doc/ja/1.0/howto/custom-file-storage.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="テンプレートタグやフィルタを自作する" href="custom-template-tags.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/howto/custom-management-commands.html
+++ b/djangoproject.jp/doc/ja/1.0/howto/custom-management-commands.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Apache での認証に Django のユーザデータベースを使う" href="apache-auth.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/howto/custom-model-fields.html
+++ b/djangoproject.jp/doc/ja/1.0/howto/custom-model-fields.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="アクションを自作する" href="custom-management-commands.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/howto/custom-template-tags.html
+++ b/djangoproject.jp/doc/ja/1.0/howto/custom-template-tags.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="カスタムのモデルフィールド" href="custom-model-fields.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/howto/deployment/fastcgi.html
+++ b/djangoproject.jp/doc/ja/1.0/howto/deployment/fastcgi.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Apache と mod_python で Django を動かす" href="modpython.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/howto/deployment/index.html
+++ b/djangoproject.jp/doc/ja/1.0/howto/deployment/index.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="カスタムのストレージシステムを作成する" href="../custom-file-storage.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/howto/deployment/modpython.html
+++ b/djangoproject.jp/doc/ja/1.0/howto/deployment/modpython.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django のデプロイ" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/howto/error-reporting.html
+++ b/djangoproject.jp/doc/ja/1.0/howto/error-reporting.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="FastCGI, SCGI, AJP で Django を使う" href="deployment/fastcgi.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/howto/index.html
+++ b/djangoproject.jp/doc/ja/1.0/howto/index.html
@@ -23,6 +23,9 @@
     <link rel="prev" title="シグナル" href="../topics/signals.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/howto/initial-data.html
+++ b/djangoproject.jp/doc/ja/1.0/howto/initial-data.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="電子メールによるエラー通知" href="error-reporting.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/howto/jython.html
+++ b/djangoproject.jp/doc/ja/1.0/howto/jython.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="モデルに初期データを与える" href="initial-data.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/howto/legacy-databases.html
+++ b/djangoproject.jp/doc/ja/1.0/howto/legacy-databases.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Jython 上で Django を動かす" href="jython.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/howto/outputting-csv.html
+++ b/djangoproject.jp/doc/ja/1.0/howto/outputting-csv.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="古いデータベースを Django に組み込む" href="legacy-databases.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/howto/outputting-pdf.html
+++ b/djangoproject.jp/doc/ja/1.0/howto/outputting-pdf.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django で CSV を出力する" href="outputting-csv.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/howto/static-files.html
+++ b/djangoproject.jp/doc/ja/1.0/howto/static-files.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django で PDF を出力する" href="outputting-pdf.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/index.html
+++ b/djangoproject.jp/doc/ja/1.0/index.html
@@ -21,6 +21,9 @@
     <link rel="top" title="Django v1.0 documentation" href="" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="">
     <div id="hd">
       <h1><a href="">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/internals/committers.html
+++ b/djangoproject.jp/doc/ja/1.0/internals/committers.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="How the Django documentation works" href="documentation.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/internals/contributing.html
+++ b/djangoproject.jp/doc/ja/1.0/internals/contributing.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django の内部" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/internals/documentation.html
+++ b/djangoproject.jp/doc/ja/1.0/internals/documentation.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django プロジェクトに協力するために" href="contributing.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/internals/index.html
+++ b/djangoproject.jp/doc/ja/1.0/internals/index.html
@@ -23,6 +23,9 @@
     <link rel="prev" title="アプリケーションを Django 0.96 から 1.0 に移行する" href="../releases/1.0-porting-guide.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/intro/index.html
+++ b/djangoproject.jp/doc/ja/1.0/intro/index.html
@@ -23,6 +23,9 @@
     <link rel="prev" title="Django ドキュメント 目次" href="../contents.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/intro/install.html
+++ b/djangoproject.jp/doc/ja/1.0/intro/install.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django の概要" href="overview.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/intro/overview.html
+++ b/djangoproject.jp/doc/ja/1.0/intro/overview.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="さあ始めましょう" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/intro/tutorial01.html
+++ b/djangoproject.jp/doc/ja/1.0/intro/tutorial01.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="インストールガイド" href="install.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/intro/tutorial02.html
+++ b/djangoproject.jp/doc/ja/1.0/intro/tutorial02.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="はじめての Django アプリ作成、その 1" href="tutorial01.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/intro/tutorial03.html
+++ b/djangoproject.jp/doc/ja/1.0/intro/tutorial03.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="はじめての Django アプリ作成、その 2" href="tutorial02.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/intro/tutorial04.html
+++ b/djangoproject.jp/doc/ja/1.0/intro/tutorial04.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="はじめての Django アプリ作成、その 3" href="tutorial03.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/intro/whatsnext.html
+++ b/djangoproject.jp/doc/ja/1.0/intro/whatsnext.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="はじめての Django アプリ作成、その 4" href="tutorial04.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/misc/api-stability.html
+++ b/djangoproject.jp/doc/ja/1.0/misc/api-stability.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="ドキュメントのドキュメント、その他" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/misc/design-philosophies.html
+++ b/djangoproject.jp/doc/ja/1.0/misc/design-philosophies.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="API の安定性" href="api-stability.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/misc/distributions.html
+++ b/djangoproject.jp/doc/ja/1.0/misc/distributions.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django の設計思想" href="design-philosophies.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/misc/index.html
+++ b/djangoproject.jp/doc/ja/1.0/misc/index.html
@@ -23,6 +23,9 @@
     <link rel="prev" title="Django での Unicode の扱い" href="../ref/unicode.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/modindex.html
+++ b/djangoproject.jp/doc/ja/1.0/modindex.html
@@ -24,6 +24,9 @@
 
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="">
     <div id="hd">
       <h1><a href="index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/obsolete/admin-css.html
+++ b/djangoproject.jp/doc/ja/1.0/obsolete/admin-css.html
@@ -23,6 +23,9 @@
     <link rel="prev" title="撤廃された機能のドキュメント" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/obsolete/index.html
+++ b/djangoproject.jp/doc/ja/1.0/obsolete/index.html
@@ -23,6 +23,9 @@
     <link rel="prev" title="Django のコミッタ" href="../internals/committers.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/admin.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/admin.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="&#8220;django.contrib&#8221; 下のアドオン" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/auth.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/auth.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django admin サイト" href="admin.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/comments/index.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/comments/index.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="django.contrib.auth" href="../auth.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/comments/settings.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/comments/settings.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="コメントフレームワーク" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/comments/signals.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/comments/signals.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="コメントフレームワークの設定" href="settings.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/comments/upgrade.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/comments/upgrade.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="コメントアプリケーションのシグナル" href="signals.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/contenttypes.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/contenttypes.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django の以前のコメントシステムからの移行" href="comments/upgrade.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/csrf.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/csrf.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="contenttypes フレームワーク" href="contenttypes.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/databrowse.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/databrowse.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="クロスサイトリクエストフォージェリ (CSRF) 対策" href="csrf.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/flatpages.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/flatpages.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="databrowse" href="databrowse.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/formtools/form-preview.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/formtools/form-preview.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="django.contrib.formtools" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/formtools/form-wizard.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/formtools/form-wizard.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="フォームプレビュー" href="form-preview.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/formtools/index.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/formtools/index.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="flatpages アプリケーション" href="../flatpages.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/humanize.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/humanize.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="フォームウィザード (Form wizard)" href="formtools/form-wizard.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/index.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/index.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="API リファレンス" href="../index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/localflavor.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/localflavor.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="django.contrib.humanize" href="humanize.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/redirects.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/redirects.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="localflavor アドオン" href="localflavor.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/sitemaps.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/sitemaps.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="redirects アプリケーション" href="redirects.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/sites.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/sites.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="sitemaps フレームワーク" href="sitemaps.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/syndication.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/syndication.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="&#8220;sites&#8221; フレームワーク" href="sites.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/contrib/webdesign.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/contrib/webdesign.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="配信フィードフレームワーク" href="syndication.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/databases.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/databases.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="django.contrib.webdesign" href="contrib/webdesign.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/django-admin.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/django-admin.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="データベースのサポート状況" href="databases.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/files/file.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/files/file.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="ファイル操作 API リファレンス" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/files/index.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/files/index.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="django-admin.py と manage.py" href="../django-admin.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/files/storage.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/files/storage.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="File オブジェクト" href="file.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/forms/api.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/forms/api.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="フォーム API" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/forms/fields.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/forms/fields.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="フォーム API" href="api.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/forms/index.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/forms/index.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="ファイルストレージ API" href="../files/storage.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/forms/validation.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/forms/validation.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="ウィジェット" href="widgets.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/forms/widgets.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/forms/widgets.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="フォームフィールド" href="fields.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/generic-views.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/generic-views.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="フォームやフィールドのバリデーション" href="forms/validation.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/index.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/index.html
@@ -23,6 +23,9 @@
     <link rel="prev" title="FAQ: コードへの貢献" href="../faq/contributing.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/middleware.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/middleware.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="汎用ビュー" href="generic-views.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/models/fields.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/models/fields.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="モデル" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/models/index.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/models/index.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="組み込みミドルウェアリファレンス" href="../middleware.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/models/instances.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/models/instances.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="モデルの Meta オプション" href="options.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/models/options.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/models/options.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="リレーションオブジェクトリファレンス" href="relations.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/models/querysets.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/models/querysets.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Model instance reference" href="instances.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/models/relations.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/models/relations.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="モデルフィールドリファレンス" href="fields.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/request-response.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/request-response.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="QuerySet API リファレンス" href="models/querysets.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/settings.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/settings.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="リクエストオブジェクトとレスポンスオブジェクト" href="request-response.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/signals.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/signals.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Available settings" href="settings.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/templates/api.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/templates/api.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="組み込みタグ／フィルタリファレンス" href="builtins.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/templates/builtins.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/templates/builtins.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="テンプレートシステムリファレンス" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/templates/index.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/templates/index.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="組み込みシグナルリファレンス" href="../signals.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/ref/unicode.html
+++ b/djangoproject.jp/doc/ja/1.0/ref/unicode.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Python プログラマのための Django テンプレート言語ガイド" href="templates/api.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/releases/0.95.html
+++ b/djangoproject.jp/doc/ja/1.0/releases/0.95.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="リリースノート" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/releases/0.96.html
+++ b/djangoproject.jp/doc/ja/1.0/releases/0.96.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django バージョン 0.95 リリースノート" href="0.95.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/releases/1.0-alpha-1.html
+++ b/djangoproject.jp/doc/ja/1.0/releases/1.0-alpha-1.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django バージョン 0.96 リリースノート" href="0.96.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/releases/1.0-alpha-2.html
+++ b/djangoproject.jp/doc/ja/1.0/releases/1.0-alpha-2.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django 1.0 alpha リリースノート" href="1.0-alpha-1.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/releases/1.0-beta-2.html
+++ b/djangoproject.jp/doc/ja/1.0/releases/1.0-beta-2.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django 1.0 beta 1 リリースノート" href="1.0-beta.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/releases/1.0-beta.html
+++ b/djangoproject.jp/doc/ja/1.0/releases/1.0-beta.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django 1.0 alpha 2 リリースノート" href="1.0-alpha-2.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/releases/1.0-porting-guide.html
+++ b/djangoproject.jp/doc/ja/1.0/releases/1.0-porting-guide.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django 1.0 リリースノート" href="1.0.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/releases/1.0.html
+++ b/djangoproject.jp/doc/ja/1.0/releases/1.0.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django 1.0 beta 2 リリースノート" href="1.0-beta-2.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/releases/index.html
+++ b/djangoproject.jp/doc/ja/1.0/releases/index.html
@@ -23,6 +23,9 @@
     <link rel="prev" title="用語集" href="../glossary.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/search.html
+++ b/djangoproject.jp/doc/ja/1.0/search.html
@@ -24,6 +24,9 @@
 
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="">
     <div id="hd">
       <h1><a href="index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/auth.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/auth.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Djangoアプリケーションのテスト" href="testing.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/cache.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/cache.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django でのユーザ認証" href="auth.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/db/index.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/db/index.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django のインストール" href="../install.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/db/managers.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/db/managers.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="クエリを生成する" href="queries.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/db/models.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/db/models.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="モデルとデータベース" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/db/queries.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/db/queries.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="モデルの作成" href="models.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/db/sql.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/db/sql.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="マネジャ" href="managers.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/db/transactions.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/db/transactions.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="SQL クエリの直接実行" href="sql.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/email.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/email.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django のキャッシュフレームワーク" href="cache.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/files.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/files.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django テンプレート言語" href="templates.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/forms/formsets.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/forms/formsets.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="モデルからフォームを生成する" href="modelforms.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/forms/index.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/forms/index.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="セッションの使い方" href="../http/sessions.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/forms/media.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/forms/media.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="フォームセット (formsets)" href="formsets.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/forms/modelforms.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/forms/modelforms.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Form Media" href="media.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/http/file-uploads.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/http/file-uploads.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="ビューを書く" href="views.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/http/generic-views.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/http/generic-views.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="ショートカット関数" href="shortcuts.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/http/index.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/http/index.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="データベーストランザクションの管理" href="../db/transactions.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/http/middleware.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/http/middleware.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="汎用ビュー (Generic views)" href="generic-views.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/http/sessions.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/http/sessions.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="ミドルウェア" href="middleware.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/http/shortcuts.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/http/shortcuts.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="ファイルアップロード" href="file-uploads.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/http/urls.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/http/urls.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="HTTP リクエストの処理" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/http/views.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/http/views.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="URL ディスパッチャ" href="urls.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/i18n.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/i18n.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="電子メールの送信" href="email.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/index.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/index.html
@@ -23,6 +23,9 @@
     <link rel="prev" title="次のステップへ" href="../intro/whatsnext.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/install.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/install.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django を使う" href="index.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/pagination.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/pagination.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="国際化" href="i18n.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/serialization.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/serialization.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="ペジネータ (paginator)" href="pagination.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/settings.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/settings.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django オブジェクトのシリアライズ" href="serialization.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/signals.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/signals.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="Django の設定" href="settings.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/templates.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/templates.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="モデルからフォームを生成する" href="forms/modelforms.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>

--- a/djangoproject.jp/doc/ja/1.0/topics/testing.html
+++ b/djangoproject.jp/doc/ja/1.0/topics/testing.html
@@ -24,6 +24,9 @@
     <link rel="prev" title="ファイルの管理" href="files.html" />
   </head>
   <body>
+  <div id="outdated-warning" class="doc-floating-warning" style="position: relative;">
+    このドキュメントの Django のバージョンにはセキュリティ上の脆弱性があるため、すでにサポートが終了されています。新しいバージョンにアップグレードしてください！<a href="https://docs.djangoproject.com/ja/">最新の Django のバージョンのドキュメントはこちら</a>
+  </div>
   <div id="custom-doc" class="yui-t6">
     <div id="hd">
       <h1><a href="../index.html">Django v1.0 documentation</a></h1>


### PR DESCRIPTION
Adapted from the upstream django/djangoproject.com:

CSS
https://github.com/django/djangoproject.com/blob/fc2bd57b5239f0710820fdc0e83d7b63eaf46eb4/djangoproject/scss/_style.scss#L2232-L2257

HTML
https://github.com/django/djangoproject.com/blob/028f4df3ef8d0b8e957ec6180ee2753c2e991543/docs/templates/docs/doc.html#L48-L50

Django 1.0のドキュメントに https://docs.djangoproject.com/ja/1.9/ のようなdeprecation warningをトップに表示する。