### PR TITLE
Remove links to docs 1.0 from header and footer

### DIFF
--- a/djangoproject.jp/about/index.html
+++ b/djangoproject.jp/about/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -219,7 +217,6 @@ About
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/community/index.html
+++ b/djangoproject.jp/community/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                active"
         id="community"><a href="/community/"
@@ -229,7 +227,6 @@ Community
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li class="active"
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/events/index.html
+++ b/djangoproject.jp/events/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                active"
         id="community"><a href="/community/"
@@ -225,7 +223,6 @@ Events
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li class="active"
             id="footer-menu-community"><a href="/community/">Community</a></li><li class="active"
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/howtojoin-transifex/index.html
+++ b/djangoproject.jp/howtojoin-transifex/index.html
@@ -94,8 +94,6 @@
         >
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
-               "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                active"
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
@@ -244,8 +242,7 @@ Transifexへのユーザー登録とDjangoドキュメント翻訳プロジェ�
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li class="active"
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="active"
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="active"
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/howtotranslate/index.html
+++ b/djangoproject.jp/howtotranslate/index.html
@@ -94,8 +94,6 @@
         >
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
-               "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                active"
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
@@ -247,8 +245,7 @@ TransifexでのDjangoドキュメント翻訳の進め方
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li class="active"
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="active"
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="active"
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/index.html
+++ b/djangoproject.jp/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -273,7 +271,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/translate/index.html
+++ b/djangoproject.jp/translate/index.html
@@ -94,8 +94,6 @@
         >
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
-               "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                active"
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
@@ -230,8 +228,7 @@
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li class="active"
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="active"
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="active"
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/translate_old/index.html
+++ b/djangoproject.jp/translate_old/index.html
@@ -94,8 +94,6 @@
         >
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
-               "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
                active"
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
@@ -252,8 +250,7 @@ git diff 007bfddc1fc4977009e431cf9706408316b682af f95baa1d8a8a96f843745118c38b7d
             id="footer-menu-whouses"><a href="/whouses/">利用実績</a></li></ul><ul class="list-unstyled"><li class="active"
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
-            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="active"
+            id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="active"
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/16_rc_15_5_release/index.html
+++ b/djangoproject.jp/weblog/16_rc_15_5_release/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -655,7 +653,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/2012/07/26/django_pyramid_con_jp/index.html
+++ b/djangoproject.jp/weblog/2012/07/26/django_pyramid_con_jp/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -746,7 +744,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/2012/09/17/django-pyramid-con-jp-2012-finished/index.html
+++ b/djangoproject.jp/weblog/2012/09/17/django-pyramid-con-jp-2012-finished/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -679,7 +677,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/2013/01/05/django_1_5_rc_1/index.html
+++ b/djangoproject.jp/weblog/2013/01/05/django_1_5_rc_1/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -643,7 +641,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/2013/02/14/djangosprint_13_2/index.html
+++ b/djangoproject.jp/weblog/2013/02/14/djangosprint_13_2/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -662,7 +660,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/2013/09/23/django_1_5_4/index.html
+++ b/djangoproject.jp/weblog/2013/09/23/django_1_5_4/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -676,7 +674,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2012/10/index.html
+++ b/djangoproject.jp/weblog/archive/2012/10/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -551,7 +549,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2012/12/index.html
+++ b/djangoproject.jp/weblog/archive/2012/12/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -497,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2012/7/index.html
+++ b/djangoproject.jp/weblog/archive/2012/7/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -497,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2012/9/index.html
+++ b/djangoproject.jp/weblog/archive/2012/9/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -605,7 +603,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/1/index.html
+++ b/djangoproject.jp/weblog/archive/2013/1/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -551,7 +549,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/11/index.html
+++ b/djangoproject.jp/weblog/archive/2013/11/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -551,7 +549,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/12/index.html
+++ b/djangoproject.jp/weblog/archive/2013/12/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -497,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/2/index.html
+++ b/djangoproject.jp/weblog/archive/2013/2/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -605,7 +603,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/3/index.html
+++ b/djangoproject.jp/weblog/archive/2013/3/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -551,7 +549,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/4/index.html
+++ b/djangoproject.jp/weblog/archive/2013/4/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -497,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/5/index.html
+++ b/djangoproject.jp/weblog/archive/2013/5/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -497,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/7/index.html
+++ b/djangoproject.jp/weblog/archive/2013/7/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -497,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/8/index.html
+++ b/djangoproject.jp/weblog/archive/2013/8/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -497,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2013/9/index.html
+++ b/djangoproject.jp/weblog/archive/2013/9/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -497,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/1/index.html
+++ b/djangoproject.jp/weblog/archive/2014/1/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -497,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/10/index.html
+++ b/djangoproject.jp/weblog/archive/2014/10/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -497,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/2/index.html
+++ b/djangoproject.jp/weblog/archive/2014/2/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -497,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/3/index.html
+++ b/djangoproject.jp/weblog/archive/2014/3/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -497,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/4/index.html
+++ b/djangoproject.jp/weblog/archive/2014/4/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -495,7 +493,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/5/index.html
+++ b/djangoproject.jp/weblog/archive/2014/5/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -495,7 +493,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/6/index.html
+++ b/djangoproject.jp/weblog/archive/2014/6/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -549,7 +547,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/7/index.html
+++ b/djangoproject.jp/weblog/archive/2014/7/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -497,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/8/index.html
+++ b/djangoproject.jp/weblog/archive/2014/8/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -497,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2014/9/index.html
+++ b/djangoproject.jp/weblog/archive/2014/9/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -497,7 +495,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2015/4/index.html
+++ b/djangoproject.jp/weblog/archive/2015/4/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -539,7 +537,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2015/5/index.html
+++ b/djangoproject.jp/weblog/archive/2015/5/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -547,7 +545,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2015/6/index.html
+++ b/djangoproject.jp/weblog/archive/2015/6/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -487,7 +485,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/archive/2016/12/index.html
+++ b/djangoproject.jp/weblog/archive/2016/12/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -495,7 +493,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -734,7 +732,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=1
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=1
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -738,7 +736,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=2
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=2
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -762,7 +760,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=3
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=3
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -758,7 +756,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=4
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=4
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -764,7 +762,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=5
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=5
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -764,7 +762,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=6
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=6
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -764,7 +762,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=7
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=7
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -764,7 +762,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=8
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=8
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -710,7 +708,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/dajngo-1-8/index.html
+++ b/djangoproject.jp/weblog/dajngo-1-8/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -644,7 +642,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/delays_in_the_final_release_of_django_1_5/index.html
+++ b/djangoproject.jp/weblog/delays_in_the_final_release_of_django_1_5/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -645,7 +643,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-1-6-alpha-1/index.html
+++ b/djangoproject.jp/weblog/django-1-6-alpha-1/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -642,7 +640,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-1-6-beta-1/index.html
+++ b/djangoproject.jp/weblog/django-1-6-beta-1/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -641,7 +639,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-16/index.html
+++ b/djangoproject.jp/weblog/django-16/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -656,7 +654,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-17-alpha-1/index.html
+++ b/djangoproject.jp/weblog/django-17-alpha-1/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -654,7 +652,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-17-beta-1/index.html
+++ b/djangoproject.jp/weblog/django-17-beta-1/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -642,7 +640,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-1_6_5/index.html
+++ b/djangoproject.jp/weblog/django-1_6_5/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -648,7 +646,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-1_7_rc_1/index.html
+++ b/djangoproject.jp/weblog/django-1_7_rc_1/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -639,7 +637,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-1_7_rc_2/index.html
+++ b/djangoproject.jp/weblog/django-1_7_rc_2/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -639,7 +637,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-girls-tokyo-announcement/index.html
+++ b/djangoproject.jp/weblog/django-girls-tokyo-announcement/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -567,7 +565,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django-pyramid-con-jp-2012-finished/index.html
+++ b/djangoproject.jp/weblog/django-pyramid-con-jp-2012-finished/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -679,7 +677,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django161/index.html
+++ b/djangoproject.jp/weblog/django161/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -643,7 +641,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django162-17a2/index.html
+++ b/djangoproject.jp/weblog/django162-17a2/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -650,7 +648,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django1_6_4/index.html
+++ b/djangoproject.jp/weblog/django1_6_4/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -634,7 +632,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_1_5/index.html
+++ b/djangoproject.jp/weblog/django_1_5/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -682,7 +680,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_1_5_1/index.html
+++ b/djangoproject.jp/weblog/django_1_5_1/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -655,7 +653,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_1_5_4/index.html
+++ b/djangoproject.jp/weblog/django_1_5_4/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -676,7 +674,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_1_5_rc_1/index.html
+++ b/djangoproject.jp/weblog/django_1_5_rc_1/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -643,7 +641,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_1_5_rc_2/index.html
+++ b/djangoproject.jp/weblog/django_1_5_rc_2/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -678,7 +676,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_1_7/index.html
+++ b/djangoproject.jp/weblog/django_1_7/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -652,7 +650,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_1_7_1/index.html
+++ b/djangoproject.jp/weblog/django_1_7_1/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -646,7 +644,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_pyramid_con_jp/index.html
+++ b/djangoproject.jp/weblog/django_pyramid_con_jp/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -746,7 +744,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/django_pyramid_con_jp_afterreport/index.html
+++ b/djangoproject.jp/weblog/django_pyramid_con_jp_afterreport/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -643,7 +641,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/djangosprint_13_2/index.html
+++ b/djangoproject.jp/weblog/djangosprint_13_2/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -662,7 +660,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/djangosprint_13_2_report/index.html
+++ b/djangoproject.jp/weblog/djangosprint_13_2_report/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -703,7 +701,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/improved-trans-page/index.html
+++ b/djangoproject.jp/weblog/improved-trans-page/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -642,7 +640,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/index.html
+++ b/djangoproject.jp/weblog/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -726,7 +724,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li class="active"

--- a/djangoproject.jp/weblog/index.html?page=1
+++ b/djangoproject.jp/weblog/index.html?page=1
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -730,7 +728,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li class="active"

--- a/djangoproject.jp/weblog/index.html?page=2
+++ b/djangoproject.jp/weblog/index.html?page=2
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -754,7 +752,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li class="active"

--- a/djangoproject.jp/weblog/index.html?page=3
+++ b/djangoproject.jp/weblog/index.html?page=3
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -750,7 +748,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li class="active"

--- a/djangoproject.jp/weblog/index.html?page=4
+++ b/djangoproject.jp/weblog/index.html?page=4
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -756,7 +754,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li class="active"

--- a/djangoproject.jp/weblog/index.html?page=5
+++ b/djangoproject.jp/weblog/index.html?page=5
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -756,7 +754,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li class="active"

--- a/djangoproject.jp/weblog/index.html?page=6
+++ b/djangoproject.jp/weblog/index.html?page=6
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -756,7 +754,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li class="active"

--- a/djangoproject.jp/weblog/index.html?page=7
+++ b/djangoproject.jp/weblog/index.html?page=7
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -756,7 +754,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li class="active"

--- a/djangoproject.jp/weblog/index.html?page=8
+++ b/djangoproject.jp/weblog/index.html?page=8
@@ -99,8 +99,6 @@
                "
         id="https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -702,7 +700,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li class="active"

--- a/djangoproject.jp/weblog/kickstarting_schema_migration_for_django/index.html
+++ b/djangoproject.jp/weblog/kickstarting_schema_migration_for_django/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -646,7 +644,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/new_djangoprojectjp/index.html
+++ b/djangoproject.jp/weblog/new_djangoprojectjp/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -642,7 +640,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/outlook-of-documents/index.html
+++ b/djangoproject.jp/weblog/outlook-of-documents/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -663,7 +661,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/released_django1_6_3/index.html
+++ b/djangoproject.jp/weblog/released_django1_6_3/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -673,7 +671,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/released_django1_6_6/index.html
+++ b/djangoproject.jp/weblog/released_django1_6_6/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -663,7 +661,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/security_release_1_4_2/index.html
+++ b/djangoproject.jp/weblog/security_release_1_4_2/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -648,7 +646,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/security_release_1_4_3/index.html
+++ b/djangoproject.jp/weblog/security_release_1_4_3/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -665,7 +663,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/security_release_1_5_2/index.html
+++ b/djangoproject.jp/weblog/security_release_1_5_2/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -709,7 +707,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/survey-for-18-translation-result/index.html
+++ b/djangoproject.jp/weblog/survey-for-18-translation-result/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -645,7 +643,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/survey-for-18-translation/index.html
+++ b/djangoproject.jp/weblog/survey-for-18-translation/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -559,7 +557,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/weblog/tokyo-django-meetup-9/index.html
+++ b/djangoproject.jp/weblog/tokyo-django-meetup-9/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -646,7 +644,6 @@ $(function() {
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 

--- a/djangoproject.jp/whouses/index.html
+++ b/djangoproject.jp/whouses/index.html
@@ -95,8 +95,6 @@
             documentation
             <b class="caret"></b></a><ul class="dropdown-menu"><li class="" id="https:--docs.djangoproject.com-ja"><a href="https://docs.djangoproject.com/ja/">日本語ドキュメント</a></li><li class="
                "
-        id="-doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li class="
-               "
         id="translate"><a href="/translate/">翻訳への参加方法</a></li></ul></li><li class="dropdown
                "
         id="community"><a href="/community/"
@@ -231,7 +229,6 @@
             id="footer-menu-https:--docs.djangoproject.com-ja-"><a href="https://docs.djangoproject.com/ja/">documentation</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-2.2-"><a href="https://docs.djangoproject.com/ja/2.2/">2.2 ドキュメント</a></li><li 
             id="footer-menu-https:--docs.djangoproject.com-ja-1.11-"><a href="https://docs.djangoproject.com/ja/1.11/">1.11ドキュメント</a></li><li 
-            id="footer-menu--doc-ja-1.0-"><a href="/doc/ja/1.0/">1.0ドキュメント</a></li><li 
             id="footer-menu-translate"><a href="/translate/">翻訳への参加方法</a></li></ul><ul class="list-unstyled"><li 
             id="footer-menu-community"><a href="/community/">Community</a></li><li 
             id="footer-menu-events"><a href="/events/">Events</a></li></ul><ul class="list-unstyled"><li 


### PR DESCRIPTION
## What

Removes links to docs 1.0 `https://djangoproject.jp/doc/ja/1.0/` from header and footer.

Leave only a single link from https://djangoproject.jp/translate/ to `https://djangoproject.jp/doc/ja/1.0/`.

## Why

Most visitors do not want to have access to docs 1.0.

