### PR TITLE
Update Trademark information

### DIFF
--- a/djangoproject.jp/about/index.html
+++ b/djangoproject.jp/about/index.html
@@ -229,7 +229,7 @@ About
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/community/index.html
+++ b/djangoproject.jp/community/index.html
@@ -239,7 +239,7 @@ Community
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/events/index.html
+++ b/djangoproject.jp/events/index.html
@@ -235,7 +235,7 @@ Events
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/howtojoin-transifex/index.html
+++ b/djangoproject.jp/howtojoin-transifex/index.html
@@ -255,7 +255,7 @@ Transifexへのユーザー登録とDjangoドキュメント翻訳プロジェ�
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/howtotranslate/index.html
+++ b/djangoproject.jp/howtotranslate/index.html
@@ -258,7 +258,7 @@ TransifexでのDjangoドキュメント翻訳の進め方
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/index.html
+++ b/djangoproject.jp/index.html
@@ -283,7 +283,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/translate/index.html
+++ b/djangoproject.jp/translate/index.html
@@ -243,7 +243,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/translate_old/index.html
+++ b/djangoproject.jp/translate_old/index.html
@@ -268,7 +268,7 @@ git diff 007bfddc1fc4977009e431cf9706408316b682af f95baa1d8a8a96f843745118c38b7d
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/16_rc_15_5_release/index.html
+++ b/djangoproject.jp/weblog/16_rc_15_5_release/index.html
@@ -665,7 +665,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/2012/07/26/django_pyramid_con_jp/index.html
+++ b/djangoproject.jp/weblog/2012/07/26/django_pyramid_con_jp/index.html
@@ -756,7 +756,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/2012/09/17/django-pyramid-con-jp-2012-finished/index.html
+++ b/djangoproject.jp/weblog/2012/09/17/django-pyramid-con-jp-2012-finished/index.html
@@ -689,7 +689,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/2013/01/05/django_1_5_rc_1/index.html
+++ b/djangoproject.jp/weblog/2013/01/05/django_1_5_rc_1/index.html
@@ -653,7 +653,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/2013/02/14/djangosprint_13_2/index.html
+++ b/djangoproject.jp/weblog/2013/02/14/djangosprint_13_2/index.html
@@ -672,7 +672,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/2013/09/23/django_1_5_4/index.html
+++ b/djangoproject.jp/weblog/2013/09/23/django_1_5_4/index.html
@@ -686,7 +686,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2012/10/index.html
+++ b/djangoproject.jp/weblog/archive/2012/10/index.html
@@ -561,7 +561,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2012/12/index.html
+++ b/djangoproject.jp/weblog/archive/2012/12/index.html
@@ -507,7 +507,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2012/7/index.html
+++ b/djangoproject.jp/weblog/archive/2012/7/index.html
@@ -507,7 +507,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2012/9/index.html
+++ b/djangoproject.jp/weblog/archive/2012/9/index.html
@@ -615,7 +615,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2013/1/index.html
+++ b/djangoproject.jp/weblog/archive/2013/1/index.html
@@ -561,7 +561,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2013/11/index.html
+++ b/djangoproject.jp/weblog/archive/2013/11/index.html
@@ -561,7 +561,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2013/12/index.html
+++ b/djangoproject.jp/weblog/archive/2013/12/index.html
@@ -507,7 +507,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2013/2/index.html
+++ b/djangoproject.jp/weblog/archive/2013/2/index.html
@@ -615,7 +615,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2013/3/index.html
+++ b/djangoproject.jp/weblog/archive/2013/3/index.html
@@ -561,7 +561,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2013/4/index.html
+++ b/djangoproject.jp/weblog/archive/2013/4/index.html
@@ -507,7 +507,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2013/5/index.html
+++ b/djangoproject.jp/weblog/archive/2013/5/index.html
@@ -507,7 +507,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2013/7/index.html
+++ b/djangoproject.jp/weblog/archive/2013/7/index.html
@@ -507,7 +507,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2013/8/index.html
+++ b/djangoproject.jp/weblog/archive/2013/8/index.html
@@ -507,7 +507,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2013/9/index.html
+++ b/djangoproject.jp/weblog/archive/2013/9/index.html
@@ -507,7 +507,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2014/1/index.html
+++ b/djangoproject.jp/weblog/archive/2014/1/index.html
@@ -507,7 +507,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2014/10/index.html
+++ b/djangoproject.jp/weblog/archive/2014/10/index.html
@@ -507,7 +507,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2014/2/index.html
+++ b/djangoproject.jp/weblog/archive/2014/2/index.html
@@ -507,7 +507,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2014/3/index.html
+++ b/djangoproject.jp/weblog/archive/2014/3/index.html
@@ -507,7 +507,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2014/4/index.html
+++ b/djangoproject.jp/weblog/archive/2014/4/index.html
@@ -505,7 +505,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2014/5/index.html
+++ b/djangoproject.jp/weblog/archive/2014/5/index.html
@@ -505,7 +505,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2014/6/index.html
+++ b/djangoproject.jp/weblog/archive/2014/6/index.html
@@ -559,7 +559,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2014/7/index.html
+++ b/djangoproject.jp/weblog/archive/2014/7/index.html
@@ -507,7 +507,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2014/8/index.html
+++ b/djangoproject.jp/weblog/archive/2014/8/index.html
@@ -507,7 +507,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2014/9/index.html
+++ b/djangoproject.jp/weblog/archive/2014/9/index.html
@@ -507,7 +507,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2015/4/index.html
+++ b/djangoproject.jp/weblog/archive/2015/4/index.html
@@ -549,7 +549,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2015/5/index.html
+++ b/djangoproject.jp/weblog/archive/2015/5/index.html
@@ -557,7 +557,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2015/6/index.html
+++ b/djangoproject.jp/weblog/archive/2015/6/index.html
@@ -497,7 +497,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/archive/2016/12/index.html
+++ b/djangoproject.jp/weblog/archive/2016/12/index.html
@@ -505,7 +505,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html
@@ -744,7 +744,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=1
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=1
@@ -748,7 +748,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=2
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=2
@@ -772,7 +772,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=3
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=3
@@ -768,7 +768,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=4
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=4
@@ -774,7 +774,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=5
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=5
@@ -774,7 +774,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=6
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=6
@@ -774,7 +774,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=7
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=7
@@ -774,7 +774,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/author/hirokiky/index.html?page=8
+++ b/djangoproject.jp/weblog/author/hirokiky/index.html?page=8
@@ -720,7 +720,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/dajngo-1-8/index.html
+++ b/djangoproject.jp/weblog/dajngo-1-8/index.html
@@ -654,7 +654,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/delays_in_the_final_release_of_django_1_5/index.html
+++ b/djangoproject.jp/weblog/delays_in_the_final_release_of_django_1_5/index.html
@@ -655,7 +655,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django-1-6-alpha-1/index.html
+++ b/djangoproject.jp/weblog/django-1-6-alpha-1/index.html
@@ -652,7 +652,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django-1-6-beta-1/index.html
+++ b/djangoproject.jp/weblog/django-1-6-beta-1/index.html
@@ -651,7 +651,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django-16/index.html
+++ b/djangoproject.jp/weblog/django-16/index.html
@@ -666,7 +666,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django-17-alpha-1/index.html
+++ b/djangoproject.jp/weblog/django-17-alpha-1/index.html
@@ -664,7 +664,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django-17-beta-1/index.html
+++ b/djangoproject.jp/weblog/django-17-beta-1/index.html
@@ -652,7 +652,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django-1_6_5/index.html
+++ b/djangoproject.jp/weblog/django-1_6_5/index.html
@@ -658,7 +658,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django-1_7_rc_1/index.html
+++ b/djangoproject.jp/weblog/django-1_7_rc_1/index.html
@@ -649,7 +649,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django-1_7_rc_2/index.html
+++ b/djangoproject.jp/weblog/django-1_7_rc_2/index.html
@@ -649,7 +649,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django-girls-tokyo-announcement/index.html
+++ b/djangoproject.jp/weblog/django-girls-tokyo-announcement/index.html
@@ -577,7 +577,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django-pyramid-con-jp-2012-finished/index.html
+++ b/djangoproject.jp/weblog/django-pyramid-con-jp-2012-finished/index.html
@@ -689,7 +689,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django161/index.html
+++ b/djangoproject.jp/weblog/django161/index.html
@@ -653,7 +653,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django162-17a2/index.html
+++ b/djangoproject.jp/weblog/django162-17a2/index.html
@@ -660,7 +660,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django1_6_4/index.html
+++ b/djangoproject.jp/weblog/django1_6_4/index.html
@@ -644,7 +644,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django_1_5/index.html
+++ b/djangoproject.jp/weblog/django_1_5/index.html
@@ -692,7 +692,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django_1_5_1/index.html
+++ b/djangoproject.jp/weblog/django_1_5_1/index.html
@@ -665,7 +665,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django_1_5_4/index.html
+++ b/djangoproject.jp/weblog/django_1_5_4/index.html
@@ -686,7 +686,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django_1_5_rc_1/index.html
+++ b/djangoproject.jp/weblog/django_1_5_rc_1/index.html
@@ -653,7 +653,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django_1_5_rc_2/index.html
+++ b/djangoproject.jp/weblog/django_1_5_rc_2/index.html
@@ -688,7 +688,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django_1_7/index.html
+++ b/djangoproject.jp/weblog/django_1_7/index.html
@@ -662,7 +662,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django_1_7_1/index.html
+++ b/djangoproject.jp/weblog/django_1_7_1/index.html
@@ -656,7 +656,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django_pyramid_con_jp/index.html
+++ b/djangoproject.jp/weblog/django_pyramid_con_jp/index.html
@@ -756,7 +756,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/django_pyramid_con_jp_afterreport/index.html
+++ b/djangoproject.jp/weblog/django_pyramid_con_jp_afterreport/index.html
@@ -653,7 +653,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/djangosprint_13_2/index.html
+++ b/djangoproject.jp/weblog/djangosprint_13_2/index.html
@@ -672,7 +672,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/djangosprint_13_2_report/index.html
+++ b/djangoproject.jp/weblog/djangosprint_13_2_report/index.html
@@ -713,7 +713,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/improved-trans-page/index.html
+++ b/djangoproject.jp/weblog/improved-trans-page/index.html
@@ -652,7 +652,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/index.html
+++ b/djangoproject.jp/weblog/index.html
@@ -736,7 +736,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/index.html?page=1
+++ b/djangoproject.jp/weblog/index.html?page=1
@@ -740,7 +740,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/index.html?page=2
+++ b/djangoproject.jp/weblog/index.html?page=2
@@ -764,7 +764,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/index.html?page=3
+++ b/djangoproject.jp/weblog/index.html?page=3
@@ -760,7 +760,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/index.html?page=4
+++ b/djangoproject.jp/weblog/index.html?page=4
@@ -766,7 +766,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/index.html?page=5
+++ b/djangoproject.jp/weblog/index.html?page=5
@@ -766,7 +766,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/index.html?page=6
+++ b/djangoproject.jp/weblog/index.html?page=6
@@ -766,7 +766,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/index.html?page=7
+++ b/djangoproject.jp/weblog/index.html?page=7
@@ -766,7 +766,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/index.html?page=8
+++ b/djangoproject.jp/weblog/index.html?page=8
@@ -712,7 +712,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/kickstarting_schema_migration_for_django/index.html
+++ b/djangoproject.jp/weblog/kickstarting_schema_migration_for_django/index.html
@@ -656,7 +656,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/new_djangoprojectjp/index.html
+++ b/djangoproject.jp/weblog/new_djangoprojectjp/index.html
@@ -652,7 +652,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/outlook-of-documents/index.html
+++ b/djangoproject.jp/weblog/outlook-of-documents/index.html
@@ -673,7 +673,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/released_django1_6_3/index.html
+++ b/djangoproject.jp/weblog/released_django1_6_3/index.html
@@ -683,7 +683,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/released_django1_6_6/index.html
+++ b/djangoproject.jp/weblog/released_django1_6_6/index.html
@@ -673,7 +673,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/security_release_1_4_2/index.html
+++ b/djangoproject.jp/weblog/security_release_1_4_2/index.html
@@ -658,7 +658,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/security_release_1_4_3/index.html
+++ b/djangoproject.jp/weblog/security_release_1_4_3/index.html
@@ -675,7 +675,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/security_release_1_5_2/index.html
+++ b/djangoproject.jp/weblog/security_release_1_5_2/index.html
@@ -719,7 +719,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/survey-for-18-translation-result/index.html
+++ b/djangoproject.jp/weblog/survey-for-18-translation-result/index.html
@@ -655,7 +655,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/survey-for-18-translation/index.html
+++ b/djangoproject.jp/weblog/survey-for-18-translation/index.html
@@ -569,7 +569,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/weblog/tokyo-django-meetup-9/index.html
+++ b/djangoproject.jp/weblog/tokyo-django-meetup-9/index.html
@@ -656,7 +656,7 @@ $(function() {
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 

--- a/djangoproject.jp/whouses/index.html
+++ b/djangoproject.jp/whouses/index.html
@@ -241,7 +241,7 @@
 						<p>
 						</p>
 	          <p>
-             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.
+             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
 	          </p>
 					</div>
 


### PR DESCRIPTION
Updates Trademark information according to its Trademark License Agreement.

- from: `             <a href="http://www.djangoproject.com/">Django</a> and the Django logo are registered trademarks of <a href="http://www.ljworld.com/">Lawrence Journal-World</a>.`
- to: `             Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.`

According to https://www2.ljworld.com/news/2008/jun/17/new_foundation_django/, Lawrence Journal World transferred the trademark and intellectual property of Django to the Foundation around 2008 😮 .

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>