### PR TITLE
Add minimal miyadaiku build and build with Vercel

### DIFF
--- a/.miyadaiku/config.yml
+++ b/.miyadaiku/config.yml
@@ -1,0 +1,6 @@
+# Miyadaiku config file
+site_url: https://djangoproject.jp/
+site_title: "- djangoproject.jp"
+lang: en-US
+charset: utf-8
+timezone: Etc/UTC

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "djangoproject.jp",
+  "version": "0.0.1",
+  "description": "Source code of http://djangoproject.jp/",
+  "scripts": {
+    "build": "npm run -s install-miyadaiku && npm run -s escape-jinja2 && npm run -s prepare-contents && npm run -s prepare-templates && miyadaiku-build work && npm run -s setup-artifacts",
+    "escape-jinja2": "sed -i -e '1i {% raw %}' -e '$a {% endraw %}' $(find . -type f -name '*.html*')",
+    "install-miyadaiku": "pip3 install miyadaiku",
+    "prepare-contents": "mkdir -p work/contents && cp .miyadaiku/config.yml work/ && mv djangoproject.jp/{about,community,events,howtojoin-transifex,howtotranslate,index.html,translate,translate_old,weblog,whouses} work/contents/",
+    "prepare-templates": "mkdir -p work/templates && echo '{{ page.html }}' | tee work/templates/page_index.html | tee work/templates/page_article.html > /dev/null",
+    "setup-artifacts": "mv work/outputs/* djangoproject.jp/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/django-ja/djangoproject.jp"
+  },
+  "keywords": [
+    "django"
+  ],
+  "author": "django-ja",
+  "contributors": [
+    "Takuya Noguchi <takninnovationresearch@gmail.com> (https://github.com/tnir)"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/django-ja/djangoproject.jp/issues"
+  },
+  "homepage": "https://djangoproject.jp"
+}


### PR DESCRIPTION
コンテンツのソースコードを一切いじらずに[miyadaiku](https://github.com/miyadaiku/miyadaiku)を導入し、Vercelでビルド＆デプロイする。

#6 はかなりコンフリクトが発生していたりするので、こちらをベースにしてテンプレートを切り出すほうがいいかもしれない。

Closes #6 

Replaces #9

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>