### PR TITLE
外部リンクを別タブで開く

### DIFF
--- a/miya/contents/about/index.html
+++ b/miya/contents/about/index.html
@@ -7,7 +7,7 @@ meta_description: DjangoDjango は Python で書かれたオープンソース�
 
 
 <h2>Django</h2>
-<p><a href="https://djangoproject.com/">Django</a> は Python で書かれたオープンソースのWebフレームワーク。見通しのよい MVC 分離、洗練された O/R マッピング API、そして汎用性の高い強力なテンプレートエンジンを備え、高い柔軟性とパフォーマンスを同時に要求されるWebアプリケーション開発をサポートしま す。 オブジェクト管理インタフェースやユーザ認証、セッション、国際化といった Webフレームワークとしての基本はもちろん、汎用のビューロジックや配信フィード (RSS/Atom) の生成など、Webアプリケーション開発に共通するメカニズムを提供し、DRY (Don't Repeat Yourself) の法則に沿った開発を、より簡単に、より迅速に実現します。 さあ、いますぐ Django を体験しましょう。</p>
+<p><a href="https://djangoproject.com/" target="_blank" rel="noopener">Django</a> は Python で書かれたオープンソースのWebフレームワーク。見通しのよい MVC 分離、洗練された O/R マッピング API、そして汎用性の高い強力なテンプレートエンジンを備え、高い柔軟性とパフォーマンスを同時に要求されるWebアプリケーション開発をサポートしま す。 オブジェクト管理インタフェースやユーザ認証、セッション、国際化といった Webフレームワークとしての基本はもちろん、汎用のビューロジックや配信フィード (RSS/Atom) の生成など、Webアプリケーション開発に共通するメカニズムを提供し、DRY (Don't Repeat Yourself) の法則に沿った開発を、より簡単に、より迅速に実現します。 さあ、いますぐ Django を体験しましょう。</p>
 <h2>django-ja</h2>
 <p>django-ja は日本の Django ユーザ有志でつくられたユーザコミュニティで、2006年2月に結成されました。</p>
 <p>djangoproject.jp ウェブサイト、Meetupイベントやメーリングリストを通じて Django に関する情報交換を行い、国内での Django の普及に努めています。</p>

--- a/miya/contents/about/index.html
+++ b/miya/contents/about/index.html
@@ -15,6 +15,6 @@ meta_description: DjangoDjango は Python で書かれたオープンソース�
 <p>djangoproject.jpのサイトは人間によって運営されています。サイトについて掲載してほしいこと、「もっとこうやったら良くなるんじゃないの?」などの提案があれば以下から連絡をください。</p>
 <ul>
 <li>master[at]djangoproject.jp</li>
-<li><a href="https://twitter.com/django_ja/" target="_blank">@django_ja</a></li>
+<li><a href="https://twitter.com/django_ja/" target="_blank" rel="noopener">@django_ja</a></li>
 </ul>
 

--- a/miya/contents/community/index.html
+++ b/miya/contents/community/index.html
@@ -10,7 +10,7 @@ meta_description: このページではコミュニティで公開されてい�
 <h2>助けが必要ですか?</h2>
 <p>解決できない問題、知りたいことがあればDiscordやメーリングリストなどで質問してみましょう。</p>
 <ul>
-<li><a href="https://discord.gg/RZvawz6KgC">Discordサーバー</a></li>
+<li><a href="https://discord.gg/RZvawz6KgC" target="_blank" rel="noopener">Discordサーバー</a></li>
 <li><a href="https://groups.google.com/forum/#!forum/django-ja" target="_blank">django-ja メーリングリスト</a></li>
 <li><a href="https://twitter.com/django_ja/" target="_blank">Twitterアカウント</a></li>
 <li><a href="/events/">開催イベント</a></li>
@@ -27,5 +27,5 @@ meta_description: このページではコミュニティで公開されてい�
 <h2><a href="https://code.djangoproject.com/wiki/NewbieMistakes" target="_blank">NewbieMistakes</a></h2>
 <p>Djangoに慣れない人が犯しがちな間違い集です。</p>
 <p>英語ですが、実例のコードを中心に説明されていて読みやすいです。チュートリアルが終わって、アプリを自分で書き始めたくらいの人が一読しておくとよいでしょう。</p>
-<p><a href="https://code.djangoproject.com/wiki/NewbieMistakes">https://code.djangoproject.com/wiki/NewbieMistakes</a></p>
+<p><a href="https://code.djangoproject.com/wiki/NewbieMistakes" target="_blank" rel="noopener">https://code.djangoproject.com/wiki/NewbieMistakes</a></p>
 

--- a/miya/contents/community/index.html
+++ b/miya/contents/community/index.html
@@ -11,20 +11,20 @@ meta_description: このページではコミュニティで公開されてい�
 <p>解決できない問題、知りたいことがあればDiscordやメーリングリストなどで質問してみましょう。</p>
 <ul>
 <li><a href="https://discord.gg/RZvawz6KgC" target="_blank" rel="noopener">Discordサーバー</a></li>
-<li><a href="https://groups.google.com/forum/#!forum/django-ja" target="_blank">django-ja メーリングリスト</a></li>
-<li><a href="https://twitter.com/django_ja/" target="_blank">Twitterアカウント</a></li>
+<li><a href="https://groups.google.com/forum/#!forum/django-ja" target="_blank" rel="noopener">django-ja メーリングリスト</a></li>
+<li><a href="https://twitter.com/django_ja/" target="_blank" rel="noopener">Twitterアカウント</a></li>
 <li><a href="/events/">開催イベント</a></li>
 </ul>
 <h2>参考になる資料集</h2>
 <p>Django公式のドキュメント以外の参考になる資料を紹介しています。</p>
 <p>日本語ドキュメント、公式のドキュメントと合わせて活用してください。</p>
 <hr>
-<h3><a href="http://eiry.bitbucket.io/" target="_blank">DjangoによるWebアプリケーション開発入門</a></h3>
+<h3><a href="http://eiry.bitbucket.io/" target="_blank" rel="noopener">DjangoによるWebアプリケーション開発入門</a></h3>
 <p>「Pythonは書けるようになったから、次にWebアプリケーションを作ってみたい。」と言う人が、Djangoの機能に触れるためのチュートリアルです。</p>
 <p>「Django基礎編」「ゲストボードを作ろう」が終わったらDjangoドキュメントにあるチュートリアルを実施してみると良いでしょう。</p>
-<p><a href="http://eiry.bitbucket.io/" target="_blank">http://eiry.bitbucket.io/</a></p>
+<p><a href="http://eiry.bitbucket.io/" target="_blank" rel="noopener">http://eiry.bitbucket.io/</a></p>
 <hr>
-<h2><a href="https://code.djangoproject.com/wiki/NewbieMistakes" target="_blank">NewbieMistakes</a></h2>
+<h2><a href="https://code.djangoproject.com/wiki/NewbieMistakes" target="_blank" rel="noopener">NewbieMistakes</a></h2>
 <p>Djangoに慣れない人が犯しがちな間違い集です。</p>
 <p>英語ですが、実例のコードを中心に説明されていて読みやすいです。チュートリアルが終わって、アプリを自分で書き始めたくらいの人が一読しておくとよいでしょう。</p>
 <p><a href="https://code.djangoproject.com/wiki/NewbieMistakes" target="_blank" rel="noopener">https://code.djangoproject.com/wiki/NewbieMistakes</a></p>

--- a/miya/contents/events/index.html
+++ b/miya/contents/events/index.html
@@ -8,12 +8,12 @@ meta_description: 開催されるイベントについては、connpassのグル
 
 <p>開催されるイベントについては、connpassのグループでまとめています。</p>
 <ul>
-<li><a href="https://django.connpass.com/">djangoja - connpass</a></li>
+<li><a href="https://django.connpass.com/" target="_blank" rel="noopener">djangoja - connpass</a></li>
 </ul>
 <h1>DjangoCongress JP</h1>
 <p>年に1回開催されるDjangoのカンファレンスです！</p>
 <p>ぜひ一年に一回のお祭りに参加してくれると嬉しいです。</p>
 <p>
-  <a href="https://djangocongress.jp/">DjangoCongress JP</a>
+  <a href="https://djangocongress.jp/" target="_blank" rel="noopener">DjangoCongress JP</a>
 </p>
 

--- a/miya/contents/howtojoin-transifex/index.html
+++ b/miya/contents/howtojoin-transifex/index.html
@@ -7,7 +7,7 @@ meta_description: TransifexのDjangoドキュメント日本語翻訳チーム�
 
 
 <h2>Transifexのプロジェクトにアクセスする</h2>
-<p><a href="https://www.transifex.com/projects/p/django-docs/">Transifexのdjango-docsプロジェクト</a>にアクセスします。以下のような画面が開きます。</p>
+<p><a href="https://www.transifex.com/projects/p/django-docs/" target="_blank" rel="noopener">Transifexのdjango-docsプロジェクト</a>にアクセスします。以下のような画面が開きます。</p>
 <p></p>
 <p><img height="270" src="/static/media/uploads/_thumbnails/ss_dj_1.png/ss_dj_1-800x270.png" width="800"/></p>
 <h2>サインアップする</h2>

--- a/miya/contents/howtotranslate/index.html
+++ b/miya/contents/howtotranslate/index.html
@@ -9,7 +9,7 @@ meta_description: Transifex上での最新のDjangoドキュメント日本語�
 <h2>ログインする</h2>
 <p>事前に<a href="/howtojoin-transifex/">アカウント作成、チームへの参加</a>をし、作成したアカウントでログインしてください。</p>
 <h2>翻訳したいリソースを開く</h2>
-<p><a href="https://www.transifex.com/django/django-docs/dashboard/">Transifexのdjango/django-docsプロジェクト</a>を開きます。</p>
+<p><a href="https://www.transifex.com/django/django-docs/dashboard/" target="_blank" rel="noopener">Transifexのdjango/django-docsプロジェクト</a>を開きます。</p>
 <p></p>
 <p><img height="499" src="/static/media/uploads/_thumbnails/ss_tr_1.png/ss_tr_1-800x499.png" width="800"/></p>
 <p></p>
@@ -20,9 +20,9 @@ meta_description: Transifex上での最新のDjangoドキュメント日本語�
 <p></p>
 <p>ここから翻訳したいリソースを選び、クリックします。それぞれはDjangoのドキュメントを大まかに分割したもので、例えば以下のようなページと対応しています。</p>
 <ul>
-<li>intro: チュートリアルなどの入門向けの内容 <a href="https://docs.djangoproject.com/en/3.1/intro/">https://docs.djangoproject.com/en/3.1/intro/</a></li>
-<li>topics: 各機能の大まかな紹介、使い方 <a href="https://docs.djangoproject.com/en/3.1/topics/">https://docs.djangoproject.com/en/3.1/topics/</a></li>
-<li>reference: APIリファレンス <a href="https://docs.djangoproject.com/en/3.1/ref/">https://docs.djangoproject.com/en/3.1/ref/</a></li>
+<li>intro: チュートリアルなどの入門向けの内容 <a href="https://docs.djangoproject.com/en/3.1/intro/" target="_blank" rel="noopener">https://docs.djangoproject.com/en/3.1/intro/</a></li>
+<li>topics: 各機能の大まかな紹介、使い方 <a href="https://docs.djangoproject.com/en/3.1/topics/" target="_blank" rel="noopener">https://docs.djangoproject.com/en/3.1/topics/</a></li>
+<li>reference: APIリファレンス <a href="https://docs.djangoproject.com/en/3.1/ref/" target="_blank" rel="noopener">https://docs.djangoproject.com/en/3.1/ref/</a></li>
 </ul>
 <p>クリックするとポップアップが開くので<strong>Translate</strong>をクリックしてください。</p>
 <p>クリックできない場合、ユーザーが作成されていないか翻訳チームに参加できていません。参加リクエストを送信済みであれば、管理者に招待されるまでお待ちください。</p>
@@ -44,6 +44,6 @@ meta_description: Transifex上での最新のDjangoドキュメント日本語�
 <p></p>
 <p>翻訳の流れは以上です。Transifexには他にも機械翻訳連携や用語集への単語追加などができますが、ここでは紹介しません。</p>
 <h2><br>翻訳後のドキュメントはどこで見れるの?</br></h2>
-<p>現状、Transifex上で進めている最新ドキュメントの翻訳は <a href="https://docs.djangoproject.com/ja/" target="_blank">https://docs.djangoproject.com/ja/</a> で公開されています。</p>
-<p>翻訳は随時反映されます。反映状況は<a href="https://github.com/django/django-docs-translations/commits/stable/3.1.x/translations/ja/LC_MESSAGES">django / django-docs-translations (stable/3.1.xブランチ)</a>のコミットログで確認できます。</p>
+<p>現状、Transifex上で進めている最新ドキュメントの翻訳は <a href="https://docs.djangoproject.com/ja/" target="_blank" rel="noopener">https://docs.djangoproject.com/ja/</a> で公開されています。</p>
+<p>翻訳は随時反映されます。反映状況は<a href="https://github.com/django/django-docs-translations/commits/stable/3.1.x/translations/ja/LC_MESSAGES" target="_blank" rel="noopener">django / django-docs-translations (stable/3.1.xブランチ)</a>のコミットログで確認できます。</p>
 

--- a/miya/contents/translate/index.html
+++ b/miya/contents/translate/index.html
@@ -22,8 +22,18 @@ meta_description: 最新ドキュメント翻訳現在ドキュメントを国�
 <h2>翻訳されたリソース一覧</h2>
 <ul>
 <li><a href="https://docs.djangoproject.com/ja/" target="_blank">Django最新版のドキュメント</a></li>
-<li>サポート中: <a href="https://docs.djangoproject.com/ja/3.1/" target="_blank">3.1</a>, <a href="https://docs.djangoproject.com/ja/3.0/" target="_blank">3.0</a>, <a href="https://docs.djangoproject.com/ja/2.2/" target="_blank">2.2</a></li>
-<li>サポート終了: <a href="https://docs.djangoproject.com/ja/2.1/" target="_blank">2.1</a>, <a href="https://docs.djangoproject.com/ja/2.0/" target="_blank">2.0</a>, <a href="https://docs.djangoproject.com/ja/1.11/" target="_blank">1.11</a>, <a href="https://docs.djangoproject.com/ja/1.10/" target="_blank">1.10</a>, <a href="/doc/ja/1.0/" target="_blank">1.0</a></li>
+<li>サポート中:
+  <a href="https://docs.djangoproject.com/ja/3.1/" target="_blank">3.1</a>,
+  <a href="https://docs.djangoproject.com/ja/3.0/" target="_blank">3.0</a>,
+  <a href="https://docs.djangoproject.com/ja/2.2/" target="_blank">2.2</a>
+</li>
+<li>サポート終了:
+  <a href="https://docs.djangoproject.com/ja/2.1/" target="_blank">2.1</a>,
+  <a href="https://docs.djangoproject.com/ja/2.0/" target="_blank">2.0</a>,
+  <a href="https://docs.djangoproject.com/ja/1.11/" target="_blank">1.11</a>,
+  <a href="https://docs.djangoproject.com/ja/1.10/" target="_blank">1.10</a>,
+  <a href="/doc/ja/1.0/" target="_blank">1.0</a>
+</li>
 <li>公開終了: 1.9, 1.4</li>
 </ul>
 <p>1.9ドキュメント以降は本家 djangoproject.com より配信されています。</p>

--- a/miya/contents/translate/index.html
+++ b/miya/contents/translate/index.html
@@ -16,7 +16,7 @@ meta_description: 最新ドキュメント翻訳現在ドキュメントを国�
 
 <h2>著作権について</h2>
 
-<p><a href="https://www.djangoproject.com/foundation/cla/">Contributor License Agreements</a> (CLA) に記載されている通り、 Django Software Foundation and individual contributors という権利者名で Django 本体同様に修正BSDライセンス(3条項)でライセンスされます。</p>
+<p><a href="https://www.djangoproject.com/foundation/cla/" target="_blank" rel="noopener">Contributor License Agreements</a> (CLA) に記載されている通り、 Django Software Foundation and individual contributors という権利者名で Django 本体同様に修正BSDライセンス(3条項)でライセンスされます。</p>
 <p>上記Django CLAにサインできない場合は、貢献された翻訳内容が遡って削除される可能性がありますので、翻訳作業開始前に上記CLAに対してサインすることをお勧めします。</p>
 
 <h2>翻訳されたリソース一覧</h2>

--- a/miya/contents/translate/index.html
+++ b/miya/contents/translate/index.html
@@ -21,18 +21,18 @@ meta_description: 最新ドキュメント翻訳現在ドキュメントを国�
 
 <h2>翻訳されたリソース一覧</h2>
 <ul>
-<li><a href="https://docs.djangoproject.com/ja/" target="_blank">Django最新版のドキュメント</a></li>
+<li><a href="https://docs.djangoproject.com/ja/" target="_blank" rel="noopener">Django最新版のドキュメント</a></li>
 <li>サポート中:
-  <a href="https://docs.djangoproject.com/ja/3.1/" target="_blank">3.1</a>,
-  <a href="https://docs.djangoproject.com/ja/3.0/" target="_blank">3.0</a>,
-  <a href="https://docs.djangoproject.com/ja/2.2/" target="_blank">2.2</a>
+  <a href="https://docs.djangoproject.com/ja/3.1/" target="_blank" rel="noopener">3.1</a>,
+  <a href="https://docs.djangoproject.com/ja/3.0/" target="_blank" rel="noopener">3.0</a>,
+  <a href="https://docs.djangoproject.com/ja/2.2/" target="_blank" rel="noopener">2.2</a>
 </li>
 <li>サポート終了:
-  <a href="https://docs.djangoproject.com/ja/2.1/" target="_blank">2.1</a>,
-  <a href="https://docs.djangoproject.com/ja/2.0/" target="_blank">2.0</a>,
-  <a href="https://docs.djangoproject.com/ja/1.11/" target="_blank">1.11</a>,
-  <a href="https://docs.djangoproject.com/ja/1.10/" target="_blank">1.10</a>,
-  <a href="/doc/ja/1.0/" target="_blank">1.0</a>
+  <a href="https://docs.djangoproject.com/ja/2.1/" target="_blank" rel="noopener">2.1</a>,
+  <a href="https://docs.djangoproject.com/ja/2.0/" target="_blank" rel="noopener">2.0</a>,
+  <a href="https://docs.djangoproject.com/ja/1.11/" target="_blank" rel="noopener">1.11</a>,
+  <a href="https://docs.djangoproject.com/ja/1.10/" target="_blank" rel="noopener">1.10</a>,
+  <a href="/doc/ja/1.0/" target="_blank" rel="noopener">1.0</a>
 </li>
 <li>公開終了: 1.9, 1.4</li>
 </ul>

--- a/miya/contents/translate_old/index.html
+++ b/miya/contents/translate_old/index.html
@@ -8,10 +8,10 @@ meta_description: 1.4ドキュメント翻訳1.4ドキュメントの翻訳はGi
 
 <h2>1.4ドキュメント翻訳</h2>
 <p>1.4ドキュメント (2018年2月 公開終了) の翻訳はGithub上での作業になります。</p>
-<p>以下の手順で、<a href="https://github.com/django/django/">本家リポジトリ</a> revision 007bfddc1fc4977009e431cf9706408316b682af から revision f95baa1d8a8a96f843745118c38b7d13824a1e38 への差分訳を行なってください。</p>
+<p>以下の手順で、<a href="https://github.com/django/django/" target="_blank" rel="noopener">本家リポジトリ</a> revision 007bfddc1fc4977009e431cf9706408316b682af から revision f95baa1d8a8a96f843745118c38b7d13824a1e38 への差分訳を行なってください。</p>
 <ol class="arabic">
 <li>
-<p><a href="https://github.com/django-docs-ja/django-docs-ja/issues">issue トラッカー</a>にアサインする。</p>
+<p><a href="https://github.com/django-docs-ja/django-docs-ja/issues" target="_blank" rel="noopener">issue トラッカー</a>にアサインする。</p>
 <p>issue トラッカーから自分自身にアサインしてください。</p>
 </li>
 <li>
@@ -33,7 +33,7 @@ git diff 007bfddc1fc4977009e431cf9706408316b682af f95baa1d8a8a96f843745118c38b7d
 <li>
 <p>diff.txt の内容に基づいて、和訳を修正する。</p>
 <p>新規に翻訳するセクションについては、もとの英訳をコメントアウトして残してください。参照:</p>
-<p><a href="https://groups.google.com/forum/?fromgroups=#%21topic/django-ja/yBAu2i6bN9Y">https://groups.google.com/forum/?fromgroups=#!topic/django-ja/yBAu2i6bN9Y</a></p>
+<p><a href="https://groups.google.com/forum/?fromgroups=#%21topic/django-ja/yBAu2i6bN9Y" target="_blank" rel="noopener">https://groups.google.com/forum/?fromgroups=#!topic/django-ja/yBAu2i6bN9Y</a></p>
 <p>注意: diff には、既存の他のドキュメントから、ほとんど変更なく移動してきたも のや、他のドキュメントにレイアウト変更されたものがあります。そのような diff を見つけたら、できるだけ、該当のドキュメントも編集するか、Issue にメモを残し てください。</p>
 </li>
 <li>
@@ -43,7 +43,7 @@ git diff 007bfddc1fc4977009e431cf9706408316b682af f95baa1d8a8a96f843745118c38b7d
 </ol>
 <h3>ルール</h3>
 <p>和訳では、75−80カラムで折り返してください。テキスト形式でも見栄えよくするためです。</p>
-<p>和訳ドキュメント中にコメントで原文を残してください。 <a href="http://sphinx-users.jp/cookbook/translation.html#id1">Sphinx クックブック</a> が参考になります。</p>
+<p>和訳ドキュメント中にコメントで原文を残してください。 <a href="http://sphinx-users.jp/cookbook/translation.html#id1" target="_blank" rel="noopener">Sphinx クックブック</a> が参考になります。</p>
 <p>原則、英数字の前後にスペースを入れます。これもテキストの見栄えのためです。</p>
 <p>専門用語に訳語を当てるときには、初出の箇所で、訳語（英語）のように書いてくださ い。固有名詞は大文字で始めます。一般名詞は、小文字ではじめます。 例：ディスパッチャー (dispacher)、 継承 (inheritance)</p>
 <h3>ビルド</h3>

--- a/miya/contents/whouses/index.html
+++ b/miya/contents/whouses/index.html
@@ -9,15 +9,15 @@ meta_description: Djangoを使ったアプリケーション、プロジェク�
 <p>Djangoを使ったアプリケーション、プロジェクトの事例一覧です</p>
 <h3>OSSでの事例</h3>
 <ul>
-<li>Horizon(OpenStack Dashboard) <a href="https://github.com/openstack/horizon">https://github.com/openstack/horizon</a></li>
-<li>Hue <a href="http://gethue.com/">http://gethue.com/</a></li>
-<li>ReadTheDocs <a href="https://github.com/rtfd/readthedocs.org">https://github.com/rtfd/readthedocs.org</a></li>
-<li>Sentry <a href="https://github.com/getsentry/sentry">https://github.com/getsentry/sentry</a></li>
-<li>djangopackages <a href="https://github.com/pydanny/djangopackages">https://github.com/pydanny/djangopackages</a></li>
-<li>Transifex <a href="https://github.com/transifex/transifex/">https://github.com/transifex/transifex/</a></li>
-<li>Open edX <a href="https://github.com/edx/edx-platform">https://github.com/edx/edx-platform</a></li>
-<li>Symposion <a href="http://t.co/alYzVPBrMD">http://eldarion.com/symposion/</a></li>
-<li>MAAS <a href="https://maas.ubuntu.com/">https://maas.ubuntu.com/</a></li>
+<li>Horizon(OpenStack Dashboard) <a href="https://github.com/openstack/horizon" target="_blank" rel="noopener">https://github.com/openstack/horizon</a></li>
+<li>Hue <a href="http://gethue.com/" target="_blank" rel="noopener">http://gethue.com/</a></li>
+<li>ReadTheDocs <a href="https://github.com/rtfd/readthedocs.org" target="_blank" rel="noopener">https://github.com/rtfd/readthedocs.org</a></li>
+<li>Sentry <a href="https://github.com/getsentry/sentry" target="_blank" rel="noopener">https://github.com/getsentry/sentry</a></li>
+<li>djangopackages <a href="https://github.com/pydanny/djangopackages" target="_blank" rel="noopener">https://github.com/pydanny/djangopackages</a></li>
+<li>Transifex <a href="https://github.com/transifex/transifex/" target="_blank" rel="noopener">https://github.com/transifex/transifex/</a></li>
+<li>Open edX <a href="https://github.com/edx/edx-platform" target="_blank" rel="noopener">https://github.com/edx/edx-platform</a></li>
+<li>Symposion <a href="http://t.co/alYzVPBrMD" target="_blank" rel="noopener">http://eldarion.com/symposion/</a></li>
+<li>MAAS <a href="https://maas.ubuntu.com/" target="_blank" rel="noopener">https://maas.ubuntu.com/</a></li>
 </ul>
 <h3>商用での事例</h3>
 <ul>
@@ -28,5 +28,5 @@ meta_description: Djangoを使ったアプリケーション、プロジェク�
 <li>Pinterest</li>
 <li>Instagram</li>
 </ul>
-<p><a href="http://jacobian.org/writing/django-community-2012/">The Django community in 2012</a></p>
+<p><a href="http://jacobian.org/writing/django-community-2012/" target="_blank" rel="noopener">The Django community in 2012</a></p>
 

--- a/miya/templates/footer.html
+++ b/miya/templates/footer.html
@@ -10,17 +10,17 @@
             <p>
             </p>
             <p>
-              Django is a <a href="https://www.djangoproject.com/trademarks/">registered trademark</a> of the Django Software Foundation.
+              Django is a <a href="https://www.djangoproject.com/trademarks/" target="_blank" rel="noopener">registered trademark</a> of the Django Software Foundation.
             </p>
           </div>
         </div>
 
         <div class="col-lg-6">
           <ul class="social-network">
-            <li><a title="" data-placement="top" href="https://twitter.com/django_ja" data-original-title="Twitter"><i class="fa fa-twitter"></i></a></li>
-            <li><a title="" data-placement="top" href="https://groups.google.com/forum/#!forum/django-ja" data-original-title="Google Group"><i class="fa fa-users"></i></a></li>
-            <li><a title="" data-placement="top" href="https://django.connpass.com/" data-original-title="Connpass"><i class="fa fa-compass"></i></a></li>
-            <li><a title="" data-placement="top" href="https://github.com/django-ja/" data-original-title="GitHub"><i class="fa fa-github"></i></a></li>
+            <li><a title="" data-placement="top" href="https://twitter.com/django_ja" target="_blank" rel="noopener" data-original-title="Twitter"><i class="fa fa-twitter"></i></a></li>
+            <li><a title="" data-placement="top" href="https://groups.google.com/forum/#!forum/django-ja" target="_blank" rel="noopener" data-original-title="Google Group"><i class="fa fa-users"></i></a></li>
+            <li><a title="" data-placement="top" href="https://django.connpass.com/" target="_blank" rel="noopener" data-original-title="Connpass"><i class="fa fa-compass"></i></a></li>
+            <li><a title="" data-placement="top" href="https://github.com/django-ja/" target="_blank" rel="noopener" data-original-title="GitHub"><i class="fa fa-github"></i></a></li>
           </ul>
         </div>
       </div>

--- a/miya/templates/template_for_home.html
+++ b/miya/templates/template_for_home.html
@@ -47,7 +47,7 @@
                     <div class="flex-caption">
                       <h3>Meet Django</h3>
                       <p>よりよいWebを簡単に、高速に作る</p>
-                      <a href="https://djangoproject.com/download/" class="btn btn-theme">Download</a>
+                      <a href="https://djangoproject.com/download/" target="_blank" rel="noopener" class="btn btn-theme">Download</a>
                     </div>
                   </li>
 
@@ -100,7 +100,7 @@
                     </p>
                   </div>
                   <div class="box-bottom">
-                    <a href="https://www.djangoproject.com/start/">Learn more</a>
+                    <a href="https://www.djangoproject.com/start/" target="_blank" rel="noopener">Learn more</a>
                   </div>
                 </div>
               </div>
@@ -117,7 +117,7 @@
                     </p>
                   </div>
                   <div class="box-bottom">
-                    <a href="https://www.djangoproject.com/start/">Learn more</a>
+                    <a href="https://www.djangoproject.com/start/" target="_blank" rel="noopener">Learn more</a>
                   </div>
                 </div>
               </div>
@@ -134,7 +134,7 @@
                     </p>
                   </div>
                   <div class="box-bottom">
-                    <a href="https://www.djangoproject.com/start/">Learn more</a>
+                    <a href="https://www.djangoproject.com/start/" target="_blank" rel="noopener">Learn more</a>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## 修正内容
- 外部リンクを別タブで開く (`target="_blank" rel="noopener"` を付与)
  - ただし、以下は**対象外**（ロジック変更が必要になるため）
    - 画面上部のドロップダウンの "Documentation"
    - フッターの "documentation"
- 別タブで開くリンクのうち、 `rel="noopener"` がなければ追加
  - 見た目上は何も変わらない
  - セキュリティ上の理由のため
    - `rel="noopener"` がない場合、リンク先サイトで `window.opener` を使ってリンク元ウィンドウを操作できてしまう可能性がある